### PR TITLE
Update indentation on library docstring so it's rendered as a list

### DIFF
--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -4,25 +4,25 @@ This library contains the Requires and Provides classes for handling
 the ingress interface.
 
 Import `IngressRequires` in your charm, with two required options:
-    - "self" (the charm itself)
-    - config_dict
+- "self" (the charm itself)
+- config_dict
 
 `config_dict` accepts the following keys:
-    - service-hostname (required)
-    - service-name (required)
-    - service-port (required)
-    - additional-hostnames
-    - limit-rps
-    - limit-whitelist
-    - max-body-size
-    - owasp-modsecurity-crs
-    - path-routes
-    - retry-errors
-    - rewrite-enabled
-    - rewrite-target
-    - service-namespace
-    - session-cookie-max-age
-    - tls-secret-name
+- service-hostname (required)
+- service-name (required)
+- service-port (required)
+- additional-hostnames
+- limit-rps
+- limit-whitelist
+- max-body-size
+- owasp-modsecurity-crs
+- path-routes
+- retry-errors
+- rewrite-enabled
+- rewrite-target
+- service-namespace
+- session-cookie-max-age
+- tls-secret-name
 
 See [the config section](https://charmhub.io/nginx-ingress-integrator/configure) for descriptions
 of each, along with the required type.


### PR DESCRIPTION
Currently this isn't correctly rendered as a list on charmhub per https://charmhub.io/nginx-ingress-integrator/libraries/ingress. Having talked with the web and design team, they've suggested it's because of the indentation, so remove that so this is correctly rendered as a list.