### PR TITLE
Increment patch level so a new library version can be published

### DIFF
--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -66,7 +66,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
In the previous change we updated the docstring for the charm library to fix formatting of lists. I had mistakenly thought that when you published a new version of the charm that library would be updated as well. It turns out you need to run `charmcraft publish-lib` specifically, so I'm incrementing the patch number here to allow me to do that.