### PR TITLE
Add whitelist-source-range annotation based on config entry

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -102,3 +102,7 @@ options:
     default: ""
     description: The name of the TLS secret to use. Leaving this empty will configure an ingress with TLS disabled.
     type: string
+  whitelist-source-range:
+    default: ""
+    description: Allowed client IP source ranges. The value is a comma separated list of CIDRs.
+    type: string

--- a/src/charm.py
+++ b/src/charm.py
@@ -241,6 +241,11 @@ class _ConfigOrRelation(object):
         """Return the tls-secret-name to use for k8s ingress (if any)."""
         return self._get_config_or_relation_data("tls-secret-name", "")
 
+    @property
+    def _whitelist_source_range(self):
+        """Return the whitelist-source-range config option."""
+        return self._get_config("whitelist-source-range")
+
     def _get_k8s_service(self):
         """Get a K8s service definition."""
         return kubernetes.client.V1Service(
@@ -329,6 +334,10 @@ class _ConfigOrRelation(object):
             ]
         else:
             annotations["nginx.ingress.kubernetes.io/ssl-redirect"] = "false"
+        if self._whitelist_source_range:
+            annotations[
+                "nginx.ingress.kubernetes.io/whitelist-source-range"
+            ] = self._whitelist_source_range
 
         return kubernetes.client.V1Ingress(
             api_version="networking.k8s.io/v1",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -446,14 +446,12 @@ class TestCharm(unittest.TestCase):
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
         self.assertEqual(conf_or_rel._whitelist_source_range, "10.0.0.0/24,172.10.0.1")
         result_dict = conf_or_rel._get_k8s_ingress().to_dict()
-        # Expect default values plus the one we've added.
-        expected = {
-            "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
-            "nginx.ingress.kubernetes.io/rewrite-target": "/",
-            "nginx.ingress.kubernetes.io/ssl-redirect": "false",
-            "nginx.ingress.kubernetes.io/whitelist-source-range": "10.0.0.0/24,172.10.0.1",
-        }
-        self.assertEqual(result_dict["metadata"]["annotations"], expected)
+        self.assertEqual(
+            result_dict["metadata"]["annotations"][
+                "nginx.ingress.kubernetes.io/whitelist-source-range"
+            ],
+            "10.0.0.0/24,172.10.0.1",
+        )
 
     def test_rewrite_annotations(self):
         self.harness.disable_hooks()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -441,6 +441,20 @@ class TestCharm(unittest.TestCase):
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
         self.assertEqual(conf_or_rel._rewrite_enabled, False)
 
+    def test_whitelist_source_range(self):
+        self.harness.update_config({"whitelist-source-range": "10.0.0.0/24,172.10.0.1"})
+        conf_or_rel = self.harness.charm._all_config_or_relations[0]
+        self.assertEqual(conf_or_rel._whitelist_source_range, "10.0.0.0/24,172.10.0.1")
+        result_dict = conf_or_rel._get_k8s_ingress().to_dict()
+        # Expect default values plus the one we've added.
+        expected = {
+            "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
+            "nginx.ingress.kubernetes.io/rewrite-target": "/",
+            "nginx.ingress.kubernetes.io/ssl-redirect": "false",
+            "nginx.ingress.kubernetes.io/whitelist-source-range": "10.0.0.0/24,172.10.0.1",
+        }
+        self.assertEqual(result_dict["metadata"]["annotations"], expected)
+
     def test_rewrite_annotations(self):
         self.harness.disable_hooks()
         self.harness.update_config(


### PR DESCRIPTION
Addresses https://github.com/canonical/nginx-ingress-integrator-operator/issues/13.

I believe this would only ever be a deploy-time option, so it's not been exposed as an option in the relation. That could obviously be changed in the future though.