### PR TITLE
Update charm to not require a workload resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ enable it with `juju expose kubernetes-worker`.
 
 ## Usage
 
-You'll need version to be using Juju [version 2.9.0](https://discourse.charmhub.io/t/juju-2-9-0-release-notes/4525) or later, and Kubernetes version 1.19 or later.
+You'll need version to be using Juju [version 2.9.23](https://discourse.charmhub.io/t/roadmap-releases/5064) or later, and Kubernetes version 1.19 or later.
 
 As an example, you could deploy this charm as follows (we're using the name
 "ingress" in this model for brevity):

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,14 +7,8 @@ summary: |
   An operator to configure a kubernetes ingress.
 docs: https://discourse.charmhub.io/t/nginx-ingress-integrator-docs-index/4511
 
-containers:
-  placeholder:
-    resource: placeholder-image
-
-resources:
-  placeholder-image:
-    type: oci-image
-    description: Docker image for placeholder - won't be used
+assumes:
+  - k8s-api
 
 provides:
   ingress:


### PR DESCRIPTION
With the `assumes` entry in metadata.yaml we can ensure this charm isn't deployable on machine models even if it doesn't have a container.

This means we no longer need the placeholder workload container.

Has been tested to not be deployable on machine models (with juju > 2.9.23). Need to test a charm upgrade from existing to this version, but currently blocked on https://bugs.launchpad.net/juju/+bug/1991511.