### PR TITLE
Add a tox target for 'woke' to check for inclusive naming in the charm

### DIFF
--- a/.woke.yml
+++ b/.woke.yml
@@ -1,0 +1,7 @@
+rules:
+  # Ignore "whitelist" - upstream uses this terminology and it would be
+  # confusing to change in this charm while upstream continues to use it.
+  # Specifically the following annotations:
+  #   - nginx.ingress.kubernetes.io/limit-whitelist
+  #   - nginx.ingress.kubernetes.io/whitelist-source-range
+  - name: whitelist

--- a/.woke.yml
+++ b/.woke.yml
@@ -4,4 +4,6 @@ rules:
   # Specifically the following annotations:
   #   - nginx.ingress.kubernetes.io/limit-whitelist
   #   - nginx.ingress.kubernetes.io/whitelist-source-range
+  # See https://github.com/kubernetes/ingress-nginx/issues/7916 for upstream
+  # issue about this.
   - name: whitelist

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ enable it with `juju expose kubernetes-worker`.
 
 ## Usage
 
-You'll need version to be using Juju [version 2.9.0](https://discourse.charmhub.io/t/juju-2-9-0-release-notes/4525) or later, and Kubernetes version 1.19 or later.
+You'll need version to be using Juju [version 2.9.23](https://discourse.charmhub.io/t/roadmap-releases/5064) or later, and Kubernetes version 1.19 or later.
 
 As an example, you could deploy this charm as follows (we're using the name
 "ingress" in this model for brevity):

--- a/check_woke.sh
+++ b/check_woke.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Check we have the 'woke' snap installed, or error out. If we do have it
+# installed, run the 'woke' command against this branch.
+
+/usr/bin/snap list woke > /dev/null
+if [ $? != 0 ]; then
+    echo "Please install woke ('sudo snap install woke') and rerun"
+    exit 1
+fi
+/snap/bin/woke

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,14 +7,8 @@ summary: |
   An operator to configure a kubernetes ingress.
 docs: https://discourse.charmhub.io/t/nginx-ingress-integrator-docs-index/4511
 
-containers:
-  placeholder:
-    resource: placeholder-image
-
-resources:
-  placeholder-image:
-    type: oci-image
-    description: Docker image for placeholder - won't be used
+assumes:
+  - k8s-api
 
 provides:
   ingress:

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+allowlist_externals=./check_woke.sh
 skipsdist=True
 envlist = unit, functional
 skip_missing_interpreters = True
@@ -50,6 +51,11 @@ commands = flake8 src/ tests/ lib/
 # Pin flake8 to 3.7.9 to match focal
 deps =
     flake8==3.7.9
+
+[testenv:woke]
+description = Run woke to check for inclusive language
+commands =
+    ./check_woke.sh
 
 [flake8]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 allowlist_externals=./check_woke.sh
 skipsdist=True
-envlist = unit, functional
+envlist = lint, woke, unit, functional
 skip_missing_interpreters = True
 
 [vars]


### PR DESCRIPTION
Add a tox target for 'woke' to check for inclusive naming in the charm.

Since this is provided by a snap, we're creating a shell command to check you have the snap installed or error out, and then run the woke command.

This isn't yet hooked up to workflows, as this charm doesn't have those yet.