### PR TITLE
Set up github workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: File a bug report
+labels: ["Type: Bug", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charm. If not, please switch to this image prior to 
+        posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to help explain the problem you are facing.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide a step-by-step instruction of how to reproduce the behavior.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju relate ...`
+        3. `juju status --relations`
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (i.e. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
+        at https://juju.is/docs/olm/juju-logs
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -1,0 +1,17 @@
+name: Enhancement Proposal
+description: File an enhancement proposal
+labels: ["Type: Enhancement", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
+        sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
+  - type: textarea
+    id: enhancement-proposal
+    attributes:
+      label: Enhancement Proposal
+      description: >
+        Describe the enhancement you would like to see in as much detail as needed.      
+    validations:
+      required: true

--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -1,0 +1,12 @@
+name: Comment on the pull request
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
+
+jobs:
+  comment-on-pr:
+    uses: canonical/operator-workflows/.github/workflows/comment.yaml@v1.0.0
+    secrets: inherit

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -1,0 +1,9 @@
+name: Integration tests
+
+on:
+  pull_request:
+
+jobs:
+  integration-tests:
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@v1.0.0
+    secrets: inherit

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -1,0 +1,19 @@
+name: Publish to edge
+
+# On push to a "special" branch, we:
+# * always publish to charmhub at latest/edge/branchname
+# * always run tests
+# where a "special" branch is one of main/master or track/**, as
+# by convention these branches are the source for a corresponding
+# charmhub edge channel.
+
+on:
+  push:
+    branches:
+      - main
+      - track/**
+
+jobs:
+  publish-to-edge:
+    uses: canonical/operator-workflows/.github/workflows/on_push.yaml@v1.0.0
+    secrets: inherit

--- a/.github/workflows/publish_branch.yaml
+++ b/.github/workflows/publish_branch.yaml
@@ -1,0 +1,12 @@
+name: Release charm to a branch in channel edge
+
+on:
+  workflow_dispatch:
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+
+jobs:
+  publish-to-edge:
+    uses: canonical/operator-workflows/.github/workflows/publish_branch.yaml@v1.0.0
+    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Promote charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      origin-channel:
+        type: choice
+        description: 'Origin Channel'
+        options:
+        - latest/edge
+      destination-channel:
+        type: choice
+        description: 'Destination Channel'
+        options:
+        - latest/stable
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+
+jobs:
+  promote-charm:
+    uses: canonical/operator-workflows/.github/workflows/release.yaml@v1.0.0
+    with:
+      origin-channel: ${{ github.event.inputs.origin-channel }}
+      destination-channel: ${{ github.event.inputs.destination-channel }}
+    secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,9 @@
+name: Tests
+
+on:
+  pull_request:
+
+jobs:
+  unit-tests:
+    uses: canonical/operator-workflows/.github/workflows/test.yaml@v1.0.0
+    secrets: inherit

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 allowlist_externals = ./check_woke.sh
 skipsdist = True
-envlist = lint, unit, integration
+envlist = lint, unit
 skip_missing_interpreters = True
 
 [vars]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-allowlist_externals=./check_woke.sh
-skipsdist=True
-envlist = lint, woke, unit, functional
+allowlist_externals = ./check_woke.sh
+skipsdist = True
+envlist = lint, unit, integration
 skip_missing_interpreters = True
 
 [vars]


### PR DESCRIPTION
Pull in github workflows for initial CI setup.

For now this isn't running the `woke` target, because we'll need to install the `woke` snap for that to work, which will require some changes to operator-workflows. This also doesn't yet include static code analysis with bandit, that will come in a later PR.