### PR TITLE
Add our check for inclusive naming to the lint target so it will happen on every CI run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,9 @@ commands =
     black {[vars]all_path}
 
 [testenv:lint]
-commands = flake8 src/ tests/ lib/
+commands =
+    flake8 src/ tests/ lib/
+    ./check_woke.sh
 # Pin flake8 to 3.7.9 to match focal
 deps =
     flake8==3.7.9


### PR DESCRIPTION
Run our inclusive naming checks as part of the `lint` target. This will mean it's triggered on every CI run.