### PR TITLE
Add missing lines to test coverage and fail under specified percentage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,14 @@ exclude_dirs = ["/venv/"]
 [tool.bandit.assert_used]
 skips = ["*/*test.py", "*/test_*.py"]
 
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+fail_under = 93
+show_missing = true
+
+
 [tool.black]
 line-length = 99

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju
+    juju==3.0.2
     pytest-operator
     pytest-asyncio
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Update pyproject.toml so that we're including missing lines in test coverage output and failing if we're under a specified percentage - pin to the current test coverage, which is 93%.