### PR TITLE
Revert to focal as k8s charm series upgrades aren't well handled currently

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,7 +2,7 @@ type: charm
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "22.04"
+      channel: "20.04"
     run-on:
     - name: "ubuntu"
-      channel: "22.04"
+      channel: "20.04"

--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,7 @@
 import logging
 import re
 import time
+from typing import List
 
 import kubernetes.client
 from charms.nginx_ingress_integrator.v0.ingress import (
@@ -409,7 +410,7 @@ class NginxIngressCharm(CharmBase):
 
         self._authed = True
 
-    def _report_service_ips(self) -> list[str]:
+    def _report_service_ips(self) -> List[str]:
         """Report on service IP(s) and return a list of them."""
         self.k8s_auth()
         api = _core_v1_api()
@@ -419,7 +420,7 @@ class NginxIngressCharm(CharmBase):
             x.spec.cluster_ip for x in services.items if x.metadata.name in all_k8s_service_names
         ]
 
-    def _report_ingress_ips(self) -> list[str]:
+    def _report_ingress_ips(self) -> List[str]:
         """Report on ingress IP(s) and return a list of them."""
         self.k8s_auth()
         api = _networking_v1_api()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,7 +34,7 @@ async def app(ops_test: OpsTest, app_name: str):
     # Build and deploy ingress
     charm = await ops_test.build_charm(".")
     application = await ops_test.model.deploy(
-        charm, application_name=app_name, series="jammy", trust=True
+        charm, application_name=app_name, series="focal", trust=True
     )
     await ops_test.model.wait_for_idle()
 


### PR DESCRIPTION
There's currently no good way to have a different series of a k8s charm in edge and stable, and be able to test upgrades from one to another (see https://bugs.launchpad.net/juju/+bug/1996590). So let's revert to focal for now. We bumped it up to jammy due to build failures on focal that have since been resolved.