### PR TITLE
Add copyright info to library, and increment version number

### DIFF
--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -1,5 +1,5 @@
 # Copyright 2022 Canonical Ltd.
-# Licensed under the GPLv3, see LICENCE file for details.
+# Licensed under the Apache2.0, see LICENCE file in charm source for details.
 """Library for the ingress relation.
 
 This library contains the Requires and Provides classes for handling

--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -1,3 +1,5 @@
+# Copyright 2022 Canonical Ltd.
+# Licensed under the GPLv3, see LICENCE file for details.
 """Library for the ingress relation.
 
 This library contains the Requires and Provides classes for handling
@@ -62,11 +64,11 @@ from ops.model import BlockedStatus
 LIBID = "db0af4367506491c91663468fb5caa4c"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 1
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
We need to increment the version number so this can be published, and charmhub has a limitation on the minor version number which means we're forced to increment `LIBAPI` (it only allows `LIBPATCH` to go up to 10)