### PR TITLE
Add owasp-modsecurity-custom-rules config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,12 +49,18 @@ options:
     type: int
   owasp-modsecurity-crs:
     default: false
-    description: >
+    description: |
       Enable OWASP ModSecurity Core Rule Set (CRS). A set of generic attack detection rules for use
       with ModSecurity or compatible web application firewalls. The CRS aims to protect web
       applications from a wide range of attacks, including the OWASP Top Ten, with a minimum of
       false alerts. See https://github.com/coreruleset/coreruleset for more details.
     type: boolean
+  owasp-modsecurity-custom-rules:
+    default: ""
+    description: >
+      /n separated list of custom rules to be added to modsecurity-snippet annotation.
+      Example: "SecAction id:900130,phase:1,nolog,pass,t:none,setvar:tx.crs_exclusions_wordpress=1\n".
+    type: string
   path-routes:
     default: ""
     description: >

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ options:
     type: string
   ingress-class:
     default: ""
-    description: >
+    description: |
       The ingress class to target for this ingress resource.
 
       If your cluster has multiple ingress controllers, this allows
@@ -31,7 +31,7 @@ options:
     type: string
   limit-rps:
     default: 0
-    description: >
+    description: |
       Number of requests accepted from a given IP each second. The burst limit
       is set to this limit multiplied by 5. When clients exceed this limit a
       503 error will be returned.
@@ -39,7 +39,7 @@ options:
     type: int
   limit-whitelist:
     default: ""
-    description: >
+    description: |
       If rate-limiting is set, client IP source ranges to be excluded. The value
       is a comma-separated list of CIDRs.
     type: string
@@ -57,19 +57,19 @@ options:
     type: boolean
   owasp-modsecurity-custom-rules:
     default: ""
-    description: >
-      /n separated list of custom rules to be added to modsecurity-snippet annotation.
+    description: |
+      New line ('\n') separated list of custom rules to be added to modsecurity-snippet annotation.
       Example: "SecAction id:900130,phase:1,nolog,pass,t:none,setvar:tx.crs_exclusions_wordpress=1\n".
     type: string
   path-routes:
     default: ""
-    description: >
+    description: |
       Comma separated list of the routes under the hostname that you wish to map to the relation.
       Example: "/admin,/portal" will map example.test/admin and example.test/portal only.
     type: string
   retry-errors:
     default: ""
-    description: >
+    description: |
       Specifies in which cases a request should be retried against the next server.
       Comma-separated list, e.g. "error,timeout,http_502,http_503,http_504".
       See http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_next_upstream

--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -69,7 +69,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 LOGGER = logging.getLogger(__name__)
 
@@ -214,7 +214,8 @@ class IngressProvides(Object):
     def _on_relation_changed(self, event):
         """Handle a change to the ingress relation.
 
-        Confirm we have the fields we expect to receive."""
+        Confirm we have the fields we expect to receive.
+        """
         # `self.unit` isn't available here, so use `self.model.unit`.
         if not self.model.unit.is_leader():
             return

--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -18,6 +18,7 @@ Import `IngressRequires` in your charm, with two required options:
 - limit-whitelist
 - max-body-size
 - owasp-modsecurity-crs
+- owasp-modsecurity-custom-rules
 - path-routes
 - retry-errors
 - rewrite-enabled
@@ -80,6 +81,7 @@ OPTIONAL_INGRESS_RELATION_FIELDS = {
     "limit-whitelist",
     "max-body-size",
     "owasp-modsecurity-crs",
+    "owasp-modsecurity-custom-rules",
     "path-routes",
     "retry-errors",
     "rewrite-target",

--- a/src/charm.py
+++ b/src/charm.py
@@ -41,7 +41,7 @@ class ConflictingRoutesError(Exception):
     pass
 
 
-class _ConfigOrRelation(object):
+class _ConfigOrRelation:
     """Class containing data from the Charm configuration, or from a relation."""
 
     def __init__(self, model, config, relation, multiple_relations):

--- a/src/charm.py
+++ b/src/charm.py
@@ -529,14 +529,16 @@ class NginxIngressCharm(CharmBase):
 
             if len(defaults) > 1:
                 default_ingress = " ".join(sorted(defaults))
+                msg = "Multiple default ingress classes defined, declining to choose between them."
                 LOGGER.warning(
-                    "Multiple default ingress classes defined, declining to choose between them. "
-                    f"They are: {default_ingress}"
+                    "%s. They are: %s",
+                    msg,
+                    default_ingress,
                 )
                 return
 
             ingress_class = defaults[0]
-            LOGGER.info(f"Using ingress class {ingress_class} as it is the cluster's default")
+            LOGGER.info("Using ingress class %s as it is the cluster's default", ingress_class)
 
         body.spec.ingress_class_name = ingress_class
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,11 +1,14 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import re
+import subprocess  # nosec B404
+import time
 from pathlib import Path
 
 import pytest_asyncio
 import yaml
-from ops.model import ActiveStatus
+from ops.model import ActiveStatus, Application
 from pytest import fixture
 from pytest_operator.plugin import OpsTest
 
@@ -50,3 +53,44 @@ async def app(ops_test: OpsTest, app_name: str):
     await ops_test.model.wait_for_idle(status=ActiveStatus.name, idle_period=120)
 
     yield application
+
+
+@pytest_asyncio.fixture(scope="module")
+async def app_ip(app: Application):
+    """Get unit IP address and add to /etc/hosts."""
+    # Get the IP address which is in the status message
+    ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
+    time.sleep(100)  # wait for ingress
+    ip_address_match = re.findall(ip_regex, app.units[0].workload_status_message)
+    assert (
+        ip_address_match
+    ), f"could not find IP address in status message: {app.units[0].workload_status_message}"
+    ip_address = ip_address_match[-1]
+    yield ip_address
+
+
+@pytest_asyncio.fixture(scope="module")
+async def app_url(app_ip: str):
+    """Add to /etc/hosts."""
+    ps = subprocess.Popen(["echo", f"{app_ip} hello-kubecon"], stdout=subprocess.PIPE)  # nosec
+    subprocess.run(["sudo", "tee", "-a", "/etc/hosts"], stdin=ps.stdout)  # nosec
+    yield "http://hello-kubecon"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def app_url_modsec(ops_test: OpsTest, app_name: str, app_url: str):
+    """Enable owasp-modsecurity-crs."""
+    await ops_test.juju("config", app_name, "owasp-modsecurity-crs=true")
+
+    yield f"{app_url}/?search=../../passwords"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def app_url_modsec_ignore(ops_test: OpsTest, app_name: str, app_url_modsec: str):
+    """Add ModSecurity Custom Rule."""
+    # Add ignore rule
+    ignore_rule = 'SecRule REQUEST_URI "/ignore" "id:1,phase:2,nolog,allow,ctl:ruleEngine=Off"\\n'
+    ignore_rule_cfg = "owasp-modsecurity-custom-rules={}".format(ignore_rule)
+    await ops_test.juju("config", app_name, ignore_rule_cfg)
+    app_url_modsec_ignore = app_url_modsec.replace("?", "ignore?")
+    yield app_url_modsec_ignore

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,10 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import re
-import subprocess  # nosec B404
-import time
-
 import pytest
 import requests
 from ops.model import ActiveStatus, Application
@@ -23,45 +19,52 @@ async def test_active(app: Application):
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_service_reachable(app: Application):
+async def test_service_reachable(app_ip: str):
     """
     arrange: given charm has been built, deployed and related to a dependent application
     act: when the dependent application is queried via the service
     assert: then the response is HTTP 200 OK.
     """
-    # Get the IP address which is in the status message
-    ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
-    time.sleep(100)
-    ip_address_match = re.findall(ip_regex, app.units[0].workload_status_message)
-    assert (
-        ip_address_match
-    ), f"could not find IP address in status message: {app.units[0].workload_status_message}"
-    ip_address = ip_address_match[-1]
     port = "8080"
-
-    response = requests.get(f"http://{ip_address}:{port}")
+    response = requests.get(f"http://{app_ip}:{port}")
 
     assert response.status_code == 200
 
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_ingress_reachable(app: Application):
+async def test_ingress_reachable(app_url: str):
     """
     arrange: given charm has been built, deployed and related to a dependent application
     act: when the dependent application is queried via the ingress
     assert: then the response is HTTP 200 OK.
     """
-    # Get the IP address which is in the status message
-    ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
-    ip_address_match = re.findall(ip_regex, app.units[0].workload_status_message)
-    assert (
-        ip_address_match
-    ), f"could not find IP address in status message: {app.units[0].workload_status_message}"
-    ip_address = ip_address_match[0]
-    ps = subprocess.Popen(["echo", f"{ip_address} hello-kubecon"], stdout=subprocess.PIPE)  # nosec
-    subprocess.run(["sudo", "tee", "-a", "/etc/hosts"], stdin=ps.stdout)  # nosec
-
-    response = requests.get("http://hello-kubecon")
+    response = requests.get(app_url)
 
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_owasp_modsecurity_crs(app_url_modsec: str):
+    """
+    arrange: given charm has been built, deployed, related to a dependent application
+        and owasp-modsecurity-crs is set to True
+    act: when the dependent application is queried via the ingress with malicious request
+    assert: then the response is HTTP 403 Forbidden for any request
+    """
+    response = requests.get(app_url_modsec)
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.abort_on_fail
+async def test_owasp_modsecurity_custom_rules(app_url_modsec_ignore: str):
+    """
+    arrange: given charm has been built, deployed, related to a dependent application,
+        owasp-modsecurity-crs is set to True and owasp-modsecurity-custom-rules has ignore rule
+    act: when the dependent application is queried via the ingress with malicious request
+    assert: then the response is HTTP 404 not found
+    """
+    response = requests.get(app_url_modsec_ignore)
+    assert response.status_code == 404

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -19,14 +19,14 @@ async def test_active(app: Application):
 
 @pytest.mark.asyncio
 @pytest.mark.abort_on_fail
-async def test_service_reachable(app_ip: str):
+async def test_service_reachable(service_ip: str):
     """
     arrange: given charm has been built, deployed and related to a dependent application
     act: when the dependent application is queried via the service
     assert: then the response is HTTP 200 OK.
     """
     port = "8080"
-    response = requests.get(f"http://{app_ip}:{port}")
+    response = requests.get(f"http://{service_ip}:{port}")
 
     assert response.status_code == 200
 
@@ -64,7 +64,7 @@ async def test_owasp_modsecurity_custom_rules(app_url_modsec_ignore: str):
     arrange: given charm has been built, deployed, related to a dependent application,
         owasp-modsecurity-crs is set to True and owasp-modsecurity-custom-rules has ignore rule
     act: when the dependent application is queried via the ingress with malicious request
-    assert: then the response is HTTP 404 not found
+    assert: then the response is HTTP 200 OK.
     """
     response = requests.get(app_url_modsec_ignore)
-    assert response.status_code == 404
+    assert response.status_code == 200

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -244,10 +244,11 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.charm._namespace, "relationnamespace")
 
     def test_owasp_modsecurity_crs(self):
-        """Test the owasp-modsecurity-crs property."""
+        """Test the owasp-modsecurity-crs and owasp-modsecurity-custom-rules properties."""
         # Test undefined.
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
         self.assertEqual(conf_or_rel._owasp_modsecurity_crs, False)
+        self.assertEqual(conf_or_rel._owasp_modsecurity_custom_rules, "")
         # Test we have no annotations with this set to False.
         self.harness.disable_hooks()
         self.harness.update_config(
@@ -268,13 +269,21 @@ class TestCharm(unittest.TestCase):
         # Test if we set the value we get the correct annotations and the
         # correct charm property.
         self.harness.update_config({"owasp-modsecurity-crs": True})
+        custom_rule = (
+            "SecAction "
+            '"id:900130,phase:1,nolog,pass,t:none,setvar:tx.crs_exclusions_wordpress=1"\n'
+        )
+        self.harness.update_config({"owasp-modsecurity-custom-rules": custom_rule})
         self.assertEqual(conf_or_rel._owasp_modsecurity_crs, True)
+        self.assertEqual(conf_or_rel._owasp_modsecurity_custom_rules, custom_rule)
         result_dict = conf_or_rel._get_k8s_ingress().to_dict()
         expected = {
             "nginx.ingress.kubernetes.io/enable-modsecurity": "true",
             "nginx.ingress.kubernetes.io/enable-owasp-modsecurity-crs": "true",
             "nginx.ingress.kubernetes.io/modsecurity-snippet": (
-                "SecRuleEngine On\nInclude /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf"
+                "SecRuleEngine On\nSecAction"
+                ' "id:900130,phase:1,nolog,pass,t:none,setvar:tx.crs_exclusions_wordpress=1"\n'
+                "Include /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf"
             ),
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",

--- a/tox.ini
+++ b/tox.ini
@@ -92,4 +92,4 @@ deps =
     pytest-asyncio
     -r{toxinidir}/requirements.txt
 commands =
-    pytest --asyncio-mode=auto -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -92,4 +92,4 @@ deps =
     pytest-asyncio
     -r{toxinidir}/requirements.txt
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest --asyncio-mode=auto -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
If owasp-modsecurity-crs is set to True, you can add custom rules via owasp-modsecurity-custom-rules.

Command example:
```bash
juju config nginx-ingress-integrator owasp-modsecurity-custom-rules='SecAction "id:900130,phase:1,nolog,pass,t:none,setvar:tx.crs_exclusions_wordpress=1"\n'
```
This PR adds:
- owasp-modsecurity-custom-rules new config
- unit test
- integration test
