### PR TITLE
Revert to publishable library version

### DIFF
--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -65,11 +65,11 @@ from ops.model import BlockedStatus
 LIBID = "db0af4367506491c91663468fb5caa4c"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 1
+LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 11
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tox.ini
+++ b/tox.ini
@@ -35,11 +35,11 @@ commands =
 description = Check code against coding style standards
 deps =
     black
-    flake8
+    flake8<6.0.0
     flake8-docstrings>=1.6.0
     flake8-copyright
     flake8-builtins
-    pyproject-flake8
+    pyproject-flake8<6.0.0
     pep8-naming
     isort
     codespell


### PR DESCRIPTION
The previously published version of the library was 0.10. This set it to 0.11 which can be published (have already done so).

This means no-one needs to update charm code to get the new version, they can simply update the existing v0.