### PR TITLE
Remove deployment section from readme, add links to juju, charms and ingress controller per feedback from docs team

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Nginx Ingress Integrator
-
-A Juju charm deploying and managing external access to HTTP/HTTPS services in a
+A [Juju](https://juju.is/) [charm](https://juju.is/docs/olm/charmed-operators) deploying and managing external access to HTTP/HTTPS services in a
 Kubernetes cluster via an Nginx Ingress resource. This requires the Kubernetes
-cluster in question to have an Nginx Ingress Controller already deployed into it.
+cluster in question to have an [Nginx Ingress Controller](https://docs.nginx.com/nginx-ingress-controller/) already deployed into it.
 
 This charm simplifies exposing services running inside a Kubernetes cluster to
 external clients. It offers TLS termination as well as easy configuration of a
@@ -15,30 +13,6 @@ access to their HTTP workloads in Kubernetes by easy integration offered via
 
 For DevOps and SRE teams, providing ingress for charms that support a relation
 to this charm will be possible via a simple `juju relate` command.
-
-## Deployment options overview
-
-For overall concepts related to using Juju
-[see the Juju overview page](https://juju.is/). For easy local testing we
-recommend
-[this how to on using MicroK8s with Juju](https://juju.is/docs/olm/microk8s).
-Because this charm requires an ingress controller, you'll also need to enable
-the `ingress` add-on by running `microk8s enable ingress`.
-
-## How to deploy this charm (quick guide)
-
-To deploy the charm and relate it to
-[the Hello Kubecon charm](https://charmhub.io/hello-kubecon) within a Juju Kubernetes model:
-
-    juju deploy nginx-ingress-integrator
-    juju deploy hello-kubecon
-    juju relate nginx-ingress-integrator hello-kubecon
-    # If your cluster has RBAC enabled you'll be prompted to run the following:
-    juju trust nginx-ingress-integrator --scope cluster
-
-Once the deployment has completed and the "hello-kubecon" workload state in
-`juju status` has changed to "active" you can visit `http://hello-kubecon` in
-a browser (assuming `hello-kubecon` resolves to the IP(s) of your k8s ingress).
 
 ## Project and community
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
 commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
+    codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml


### PR DESCRIPTION
Some documentation updates based on feedback from the docs team. The deployment section has been moved to discourse-based documentation.