### PR TITLE
fix(ISD-359): Add kubernetes library version to status message

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -768,7 +768,16 @@ class NginxIngressCharm(CharmBase):
                     "Duplicate route found; cannot add ingress. Run juju debug-log for details."
                 )
                 return
+        self.unit.set_workload_version(self._get_kubernetes_library_version())
         self.unit.status = ActiveStatus(msg)
+
+    def _get_kubernetes_library_version(self) -> str:
+        """Retrieve the current version of Kubernetes library.
+
+        Returns:
+            The Kubernetes library used.
+        """
+        return kubernetes.__version__
 
     def _on_ingress_broken(self, event):
         """Handle the ingress broken event."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -25,7 +25,11 @@ class TestCharm(unittest.TestCase):
     @patch("charm.NginxIngressCharm._define_ingress")
     @patch("charm.NginxIngressCharm._define_service")
     def test_config_changed(
-        self, _define_service, _define_ingress, _report_service_ips, _report_ingress_ips
+        self,
+        _define_service,
+        _define_ingress,
+        _report_service_ips,
+        _report_ingress_ips,
     ):
         """
         arrange: given the harnessed charm
@@ -60,6 +64,11 @@ class TestCharm(unittest.TestCase):
             self.harness.charm.unit.status,
             ActiveStatus("Ingress IP(s): 10.0.1.12, Service IP(s): 10.0.1.13"),
         )
+        # Confirm version is set correctly
+        self.assertEqual(
+            self.harness.get_workload_version(),
+            self.harness.charm._get_kubernetes_library_version(),
+        )
         # And now test with leader is False.
         _define_ingress.reset_mock()
         _define_service.reset_mock()
@@ -73,6 +82,11 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(_define_service.call_count, 0)
         # Confirm status is as expected.
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+        # Confirm version is set correctly
+        self.assertEqual(
+            self.harness.get_workload_version(),
+            self.harness.charm._get_kubernetes_library_version(),
+        )
 
         # Confirm if we get a 403 error from k8s API we block with an appropriate message.
         _define_ingress.reset_mock()


### PR DESCRIPTION
nginx-ingress-integrator reports kubernetes livrary version in juju status

Example (nginx1):

![image](https://user-images.githubusercontent.com/12564014/214118607-329c33e4-c208-4a97-8a64-b01eaafb72b4.png)
