### PR TITLE
fix(ISD-362): Remove unused resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ branch = true
 fail_under = 93
 show_missing = true
 
+[tool.mypy]
+ignore_missing_imports = true
+allow_redefinition = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ fail_under = 93
 show_missing = true
 
 [tool.mypy]
-ignore_missing_imports = true
-allow_redefinition = true
+check_untyped_defs = true
+disallow_untyped_defs = true
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-log_cli_level = "INFO"
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
 
 # Formatting tools configuration
 [tool.black]

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,6 +23,9 @@ from ops.model import ActiveStatus, BlockedStatus
 LOGGER = logging.getLogger(__name__)
 _INGRESS_SUB_REGEX = re.compile("[^0-9a-zA-Z]")
 BOOLEAN_CONFIG_FIELDS = ["rewrite-enabled"]
+# Juju defines the value of this label.
+# It has the same value as the label "app.kubernetes.io/name"
+# set in the service account associated with the application.
 CREATED_BY_LABEL = "app.juju.is/created-by="
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,7 @@
 import logging
 import re
 import time
-from typing import List
+from typing import Generator, List
 
 import kubernetes.client
 from charms.nginx_ingress_integrator.v0.ingress import (
@@ -121,14 +121,16 @@ class _ConfigOrRelation:
         return fallback
 
     @property
-    def _additional_hostnames(self) -> List[str]:
+    def _additional_hostnames(self) -> Generator[str, None, None]:
         """Return a list with additional hostnames.
 
         Returns:
             The additional hostnames set by configuration already split by comma.
         """
         additional_hostnames = self._get_config_or_relation_data("additional-hostnames", "")
-        return [hostname for hostname in additional_hostnames.split(",") if hostname]
+        for hostname in additional_hostnames.split(","):
+            if hostname:
+                yield hostname
 
     @property
     def _k8s_service_name(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,10 +9,10 @@
 import logging
 import re
 import time
-from typing import Generator, List
+from typing import Any, Generator, List
 
-import kubernetes.client
-from charms.nginx_ingress_integrator.v0.ingress import (
+import kubernetes.client  # type: ignore[import]
+from charms.nginx_ingress_integrator.v0.ingress import (  # type: ignore[import]
     RELATION_INTERFACES_MAPPINGS,
     REQUIRED_INGRESS_RELATION_FIELDS,
     IngressCharmEvents,
@@ -28,19 +28,7 @@ BOOLEAN_CONFIG_FIELDS = ["rewrite-enabled"]
 # Juju defines the value of this label.
 # It has the same value as the label "app.kubernetes.io/name"
 # set in the service account associated with the application.
-KUBERNETES_CORE_API = "core"
-KUBERNETES_NETWORKING_API = "networking"
 CREATED_BY_LABEL = "app.juju.is/created-by="
-
-
-def _core_v1_api():
-    """Use the v1 k8s API."""
-    return kubernetes.client.CoreV1Api()
-
-
-def _networking_v1_api():
-    """Use the v1 beta1 networking API."""
-    return kubernetes.client.NetworkingV1Api()
 
 
 class ConflictingAnnotationsError(Exception):
@@ -54,7 +42,9 @@ class ConflictingRoutesError(Exception):
 class _ConfigOrRelation:
     """Class containing data from the Charm configuration, or from a relation."""
 
-    def __init__(self, model, config, relation, multiple_relations):
+    def __init__(  # type: ignore[no-untyped-def]
+        self, model, config, relation, multiple_relations
+    ) -> None:
         """Create a _ConfigOrRelation Object.
 
         :param model: The charm model.
@@ -68,7 +58,7 @@ class _ConfigOrRelation:
         self.relation = relation
         self.multiple_relations = multiple_relations
 
-    def _get_config(self, field):
+    def _get_config(self, field: Any) -> Any:
         """Get data from config."""
         # Config fields with a default of None don't appear in the dict
         config_data = self.config.get(field, None)
@@ -80,7 +70,7 @@ class _ConfigOrRelation:
 
         return None
 
-    def _get_relation(self, field):
+    def _get_relation(self, field: Any) -> Any:
         """Get data from the relation, if any."""
         if self.relation:
             try:
@@ -98,7 +88,7 @@ class _ConfigOrRelation:
                 return None
         return None
 
-    def _get_config_or_relation_data(self, field, fallback):
+    def _get_config_or_relation_data(self, field: Any, fallback: Any) -> Any:
         """Get data from config or the ingress relation, in that order."""
         data = self._get_config(field)
         if data is not None:
@@ -110,7 +100,7 @@ class _ConfigOrRelation:
 
         return fallback
 
-    def _get_relation_data_or_config(self, field, fallback):
+    def _get_relation_data_or_config(self, field: Any, fallback: Any) -> Any:
         """Get data from the ingress relation or config, in that order."""
         data = self._get_relation(field)
         if data is not None:
@@ -130,12 +120,10 @@ class _ConfigOrRelation:
             The additional hostnames set by configuration already split by comma.
         """
         additional_hostnames = self._get_config_or_relation_data("additional-hostnames", "")
-        for hostname in additional_hostnames.split(","):
-            if hostname:
-                yield hostname
+        yield from filter(None, additional_hostnames.split(","))
 
     @property
-    def _k8s_service_name(self):
+    def _k8s_service_name(self) -> str:
         """Return a service name for the use creating a k8s service."""
         # Avoid collision with service name created by Juju. Currently
         # Juju creates a K8s service listening on port 65535/TCP so we
@@ -143,7 +131,7 @@ class _ConfigOrRelation:
         return f"{self._service_name}-service"
 
     @property
-    def _ingress_name(self):
+    def _ingress_name(self) -> str:
         """Return an ingress name for use creating a k8s ingress."""
         # If there are 2 or more services configured to use the same service-hostname, the
         # controller nginx/nginx-ingress requires them to be in the same Kubernetes Ingress object.
@@ -155,7 +143,7 @@ class _ConfigOrRelation:
         return f"{ingress_name}-ingress"
 
     @property
-    def _limit_rps(self):
+    def _limit_rps(self) -> str:
         """Return limit-rps value from config or relation."""
         limit_rps = self._get_config_or_relation_data("limit-rps", 0)
         if limit_rps:
@@ -164,24 +152,24 @@ class _ConfigOrRelation:
         return ""
 
     @property
-    def _limit_whitelist(self):
+    def _limit_whitelist(self) -> str:
         """Return the limit-whitelist value from config or relation."""
         return self._get_config_or_relation_data("limit-whitelist", "")
 
     @property
-    def _max_body_size(self):
+    def _max_body_size(self) -> str:
         """Return the max-body-size to use for k8s ingress."""
         max_body_size = self._get_config_or_relation_data("max-body-size", 0)
         return f"{max_body_size}m"
 
     @property
-    def _owasp_modsecurity_crs(self):
+    def _owasp_modsecurity_crs(self) -> bool:
         """Return a boolean indicating whether OWASP ModSecurity CRS is enabled."""
         value = self._get_config_or_relation_data("owasp-modsecurity-crs", False)
         return str(value).lower() == "true"
 
     @property
-    def _owasp_modsecurity_custom_rules(self):
+    def _owasp_modsecurity_custom_rules(self) -> str:
         r"""Return the owasp-modsecurity-custom-rules value from config or relation.
 
         Since when setting the config via CLI or via YAML file, the new line character ('\n')
@@ -192,7 +180,7 @@ class _ConfigOrRelation:
         )
 
     @property
-    def _rewrite_enabled(self):
+    def _rewrite_enabled(self) -> bool:
         """Return whether rewriting should be enabled from config or relation."""
         value = self._get_config_or_relation_data("rewrite-enabled", True)
         # config data is typed, relation data is a string
@@ -200,17 +188,17 @@ class _ConfigOrRelation:
         return str(value).lower() == "true"
 
     @property
-    def _rewrite_target(self):
+    def _rewrite_target(self) -> Any:
         """Return the rewrite target from config or relation."""
         return self._get_config_or_relation_data("rewrite-target", "/")
 
     @property
-    def _namespace(self):
+    def _namespace(self) -> Any:
         """Return the namespace to operate on."""
         return self._get_config_or_relation_data("service-namespace", self.model.name)
 
     @property
-    def _retry_errors(self):
+    def _retry_errors(self) -> str:
         """Return the retry-errors setting from config or relation."""
         retry = self._get_config_or_relation_data("retry-errors", "")
         if not retry:
@@ -233,12 +221,12 @@ class _ConfigOrRelation:
         return " ".join([x.strip() for x in retry.split(",") if x.strip() in accepted_values])
 
     @property
-    def _service_hostname(self):
+    def _service_hostname(self) -> Any:
         """Return the hostname for the service we're connecting to."""
         return self._get_config_or_relation_data("service-hostname", "")
 
     @property
-    def _service_name(self):
+    def _service_name(self) -> Any:
         """Return the name of the service we're connecting to."""
         # NOTE: If the charm has multiple relations, use the service name given by the relation
         # in order to avoid service name conflicts.
@@ -247,7 +235,7 @@ class _ConfigOrRelation:
         return self._get_config_or_relation_data("service-name", "")
 
     @property
-    def _service_port(self):
+    def _service_port(self) -> Any:
         """Return the port for the service we're connecting to."""
         # NOTE: If the charm has multiple relations, use the service port given by the relation.
         if self.multiple_relations:
@@ -255,7 +243,7 @@ class _ConfigOrRelation:
         return int(self._get_relation_data_or_config("service-port", 0))
 
     @property
-    def _path_routes(self):
+    def _path_routes(self) -> Any:
         """Return the path routes to use for the k8s ingress."""
         # NOTE: If the charm has multiple relations, use the path routes given by the relation
         # in order to avoid same route conflicts.
@@ -264,7 +252,7 @@ class _ConfigOrRelation:
         return self._get_config_or_relation_data("path-routes", "/").split(",")
 
     @property
-    def _session_cookie_max_age(self):
+    def _session_cookie_max_age(self) -> Any:
         """Return the session-cookie-max-age to use for k8s ingress."""
         session_cookie_max_age = self._get_config_or_relation_data("session-cookie-max-age", 0)
         if session_cookie_max_age:
@@ -273,16 +261,16 @@ class _ConfigOrRelation:
         return ""
 
     @property
-    def _tls_secret_name(self):
+    def _tls_secret_name(self) -> Any:
         """Return the tls-secret-name to use for k8s ingress (if any)."""
         return self._get_config_or_relation_data("tls-secret-name", "")
 
     @property
-    def _whitelist_source_range(self):
+    def _whitelist_source_range(self) -> Any:
         """Return the whitelist-source-range config option."""
         return self._get_config("whitelist-source-range")
 
-    def _get_k8s_service(self):
+    def _get_k8s_service(self) -> Any:
         """Get a K8s service definition."""
         return kubernetes.client.V1Service(
             api_version="v1",
@@ -300,7 +288,7 @@ class _ConfigOrRelation:
             ),
         )
 
-    def _get_k8s_ingress(self):
+    def _get_k8s_ingress(self) -> Any:
         """Get a K8s ingress definition."""
         ingress_paths = [
             kubernetes.client.V1HTTPIngressPath(
@@ -388,7 +376,7 @@ class NginxIngressCharm(CharmBase):
     _authed = False
     on = IngressCharmEvents()
 
-    def __init__(self, *args):
+    def __init__(self, *args) -> None:  # type: ignore[no-untyped-def]
         """Init function for the class.
 
         Args:
@@ -405,9 +393,9 @@ class NginxIngressCharm(CharmBase):
         self.framework.observe(self.on.ingress_broken, self._on_ingress_broken)
 
     @property
-    def _all_config_or_relations(self):
+    def _all_config_or_relations(self) -> Any:
         """Get all configuration and relation data."""
-        all_relations = self.model.relations["ingress"] or [None]
+        all_relations = self.model.relations["ingress"] or [None]  # type: ignore[list-item]
         multiple_rels = self._multiple_relations
         return [
             _ConfigOrRelation(self.model, self.config, relation, multiple_rels)
@@ -415,12 +403,12 @@ class NginxIngressCharm(CharmBase):
         ]
 
     @property
-    def _multiple_relations(self):
+    def _multiple_relations(self) -> bool:
         """Return a boolean indicating if we're related to multiple applications."""
         return len(self.model.relations["ingress"]) > 1
 
     @property
-    def _namespace(self):
+    def _namespace(self) -> Any:
         """Namespace for this ingress."""
         # We're querying the first one here because this will always be the same
         # for all instances. It would be very unusual for a relation to specify
@@ -428,13 +416,13 @@ class NginxIngressCharm(CharmBase):
         # via config it will be the same for all relations.
         return self._all_config_or_relations[0]._namespace
 
-    def _describe_ingresses_action(self, event):
+    def _describe_ingresses_action(self, event: Any) -> None:
         """Handle the 'describe-ingresses' action."""
-        api = self.k8s_api(api=KUBERNETES_NETWORKING_API)
+        api = self._networking_v1_api()
         ingresses = api.list_namespaced_ingress(namespace=self._namespace)
         event.set_results({"ingresses": ingresses})
 
-    def k8s_auth(self):
+    def k8s_auth(self) -> None:
         """Authenticate to kubernetes."""
         if self._authed:
             return
@@ -443,23 +431,19 @@ class NginxIngressCharm(CharmBase):
 
         self._authed = True
 
-    def k8s_api(self, api: str) -> object:
-        """Authenticate and return a k8s API.
-
-        Args:
-            api: Which API should be returned. If is not found, None is returned.
-        """
+    def _core_v1_api(self) -> Any:
+        """Use the v1 k8s API."""
         self.k8s_auth()
-        if api == KUBERNETES_CORE_API:
-            return _core_v1_api()
-        if api == KUBERNETES_NETWORKING_API:
-            return _networking_v1_api()
-        LOGGER.error("k8s api %s not found", api)
-        return None
+        return kubernetes.client.CoreV1Api()
+
+    def _networking_v1_api(self) -> Any:
+        """Use the v1 beta1 networking API."""
+        self.k8s_auth()
+        return kubernetes.client.NetworkingV1Api()
 
     def _report_service_ips(self) -> List[str]:
         """Report on service IP(s) and return a list of them."""
-        api = self.k8s_api(KUBERNETES_CORE_API)
+        api = self._core_v1_api()
         services = api.list_namespaced_service(  # type: ignore[attr-defined]
             namespace=self._namespace
         )
@@ -470,7 +454,7 @@ class NginxIngressCharm(CharmBase):
 
     def _report_ingress_ips(self) -> List[str]:
         """Report on ingress IP(s) and return a list of them."""
-        api = self.k8s_api(KUBERNETES_NETWORKING_API)
+        api = self._networking_v1_api()
         # Wait up to `interval * count` seconds for ingress IPs.
         count, interval = 100, 1
         for _ in range(count):
@@ -488,7 +472,7 @@ class NginxIngressCharm(CharmBase):
             time.sleep(interval)
         return ips
 
-    def _has_required_fields(self, conf_or_rel: _ConfigOrRelation):
+    def _has_required_fields(self, conf_or_rel: _ConfigOrRelation) -> bool:
         """Check if the given config or relation has the required fields set."""
         # We use the same names in _ConfigOrRelation, but with _ instead of -.
         field_names = [f'_{f.replace("-", "_")}' for f in REQUIRED_INGRESS_RELATION_FIELDS]
@@ -504,7 +488,7 @@ class NginxIngressCharm(CharmBase):
             current_svc_names: service names set by config or relation data
             current_svc_hostnames: service hostnames set by config or relation data
         """
-        api = self.k8s_api(KUBERNETES_CORE_API)
+        api = self._core_v1_api()
         all_services = api.list_namespaced_service(  # type: ignore[attr-defined]
             namespace=self._namespace, label_selector=self._get_created_label()
         )
@@ -531,7 +515,7 @@ class NginxIngressCharm(CharmBase):
                 unused_svc_name,
             )
 
-    def _define_services(self):
+    def _define_services(self) -> None:
         """Create or update the services in Kubernetes from multiple ingress relations."""
         for conf_or_rel in self._all_config_or_relations:
             # By default, the service name is "". If there is no value set, we might be missing
@@ -540,9 +524,9 @@ class NginxIngressCharm(CharmBase):
             if self._has_required_fields(conf_or_rel):
                 self._define_service(conf_or_rel)
 
-    def _define_service(self, conf_or_rel: _ConfigOrRelation):
+    def _define_service(self, conf_or_rel: _ConfigOrRelation) -> None:
         """Create or update a service in kubernetes."""
-        api = self.k8s_api(KUBERNETES_CORE_API)
+        api = self._core_v1_api()
         body = conf_or_rel._get_k8s_service()
         services = api.list_namespaced_service(  # type: ignore[attr-defined]
             namespace=self._namespace
@@ -569,9 +553,9 @@ class NginxIngressCharm(CharmBase):
                 conf_or_rel._service_name,
             )
 
-    def _remove_service(self, conf_or_rel: _ConfigOrRelation):
+    def _remove_service(self, conf_or_rel: _ConfigOrRelation) -> None:
         """Remove the created service in kubernetes."""
-        api = self.k8s_api(KUBERNETES_CORE_API)
+        api = self._core_v1_api()
         services = api.list_namespaced_service(  # type: ignore[attr-defined]
             namespace=self._namespace
         )
@@ -586,7 +570,7 @@ class NginxIngressCharm(CharmBase):
                 conf_or_rel._service_name,
             )
 
-    def _look_up_and_set_ingress_class(self, api, body):
+    def _look_up_and_set_ingress_class(self, api: Any, body: Any) -> None:
         """Set the configured ingress class, otherwise the cluster's default ingress class."""
         ingress_class = self.config["ingress-class"]
         if not ingress_class:
@@ -622,7 +606,7 @@ class NginxIngressCharm(CharmBase):
         Args:
             current_svc_hostnames: service hostnames set by config or relation data
         """
-        api = self.k8s_api(KUBERNETES_NETWORKING_API)
+        api = self._networking_v1_api()
         all_ingresses = api.list_namespaced_ingress(  # type: ignore[attr-defined]
             namespace=self._namespace, label_selector=self._get_created_label()
         )
@@ -639,7 +623,7 @@ class NginxIngressCharm(CharmBase):
         for unused_src_hostname in unused_svc_hostnames:
             self._remove_ingress(self._ingress_name(unused_src_hostname))
 
-    def _define_ingresses(self, excluded_relation=None):
+    def _define_ingresses(self, excluded_relation=None) -> None:  # type: ignore[no-untyped-def]
         """(Re)Creates the Ingress Resources in Kubernetes from multiple ingress relations.
 
         Creates the Kubernetes Ingress Resource if it does not exist, or updates it if it does.
@@ -682,7 +666,7 @@ class NginxIngressCharm(CharmBase):
         for ingress in ingresses:
             self._define_ingress(ingress)
 
-    def _process_ingresses(self, ingresses):
+    def _process_ingresses(self, ingresses: List) -> List:
         """Process ingresses, or raise an exception if there are unresolvable conflicts."""
         # If there are Ingress rules for the same service-hostname, we need to squash those
         # rules together. This will be used to group the rules by their host.
@@ -718,18 +702,17 @@ class NginxIngressCharm(CharmBase):
 
                 # Ensure that the exact same route for this route was not yet defined.
                 defined_paths = ingress_paths[rule.host]
-                for path in rule.http.paths:
-                    duplicate_paths = list(
-                        filter(
-                            lambda p: p.path == path.path,  # pylint: disable=cell-var-from-loop
-                            defined_paths,
-                        )
-                    )
+                for item in rule.http.paths:
+                    duplicate_paths = [
+                        defined_path
+                        for defined_path in defined_paths
+                        if defined_path.path == item.path
+                    ]
                     if duplicate_paths:
                         LOGGER.error(
                             "Duplicate routes found:\nFirst route: %s\nSecond route: %s",
                             duplicate_paths[0],
-                            path,
+                            item,
                         )
                         raise ConflictingRoutesError()
 
@@ -746,12 +729,12 @@ class NginxIngressCharm(CharmBase):
 
         return ingress_objs
 
-    def _ingress_name(self, hostname):
+    def _ingress_name(self, hostname: str) -> str:
         """Return the Kubernetes Ingress Resource name based on the given hostname."""
         ingress_name = _INGRESS_SUB_REGEX.sub("-", hostname)
         return f"{ingress_name}-ingress"
 
-    def _create_k8s_ingress_obj(self, svc_hostname, initial_ingress, paths):
+    def _create_k8s_ingress_obj(self, svc_hostname: str, initial_ingress: Any, paths: Any) -> Any:
         """Create a Kubernetes Ingress Resources with the given data."""
         # Create a Ingress Object with the new ingress rules and return it.
         rule = kubernetes.client.V1IngressRule(
@@ -780,9 +763,9 @@ class NginxIngressCharm(CharmBase):
             spec=new_spec,
         )
 
-    def _define_ingress(self, body):
+    def _define_ingress(self, body: Any) -> None:
         """Create or update an ingress in kubernetes."""
-        api = self.k8s_api(KUBERNETES_NETWORKING_API)
+        api = self._networking_v1_api()
         self._look_up_and_set_ingress_class(api, body)
         ingress_name = body.metadata.name
         ingresses = api.list_namespaced_ingress(namespace=self._namespace)
@@ -808,9 +791,9 @@ class NginxIngressCharm(CharmBase):
                 ingress_name,
             )
 
-    def _remove_ingress(self, ingress_name):
+    def _remove_ingress(self, ingress_name: str) -> None:
         """Remove ingress resource."""
-        api = self.k8s_api(KUBERNETES_NETWORKING_API)
+        api = self._networking_v1_api()
         ingresses = api.list_namespaced_ingress(namespace=self._namespace)
         if ingress_name in [x.metadata.name for x in ingresses.items]:
             api.delete_namespaced_ingress(ingress_name, self._namespace)
@@ -834,7 +817,7 @@ class NginxIngressCharm(CharmBase):
             svc_hostnames.extend(additional_hostname)
         self._delete_unused_ingresses(svc_hostnames)
 
-    def _on_config_changed(self, _):
+    def _on_config_changed(self, _) -> None:  # type: ignore[no-untyped-def]
         """Handle the config changed event."""
         msg = ""
         # We only want to do anything here if we're the leader to avoid
@@ -885,7 +868,7 @@ class NginxIngressCharm(CharmBase):
         """
         return kubernetes.__version__
 
-    def _on_ingress_broken(self, event):
+    def _on_ingress_broken(self, event: Any) -> None:
         """Handle the ingress broken event."""
         conf_or_rel = _ConfigOrRelation(self.model, {}, event.relation, self._multiple_relations)
         if self.unit.is_leader() and conf_or_rel._ingress_name:

--- a/src/charm.py
+++ b/src/charm.py
@@ -127,13 +127,8 @@ class _ConfigOrRelation:
         Returns:
             The additional hostnames set by configuration already split by comma.
         """
-        return [
-            hostname
-            for hostname in self._get_config_or_relation_data("additional-hostnames", "").split(
-                ","
-            )
-            if hostname
-        ]
+        additional_hostnames = self._get_config_or_relation_data("additional-hostnames", "")
+        return [hostname for hostname in additional_hostnames.split(",") if hostname]
 
     @property
     def _k8s_service_name(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -123,9 +123,11 @@ class _ConfigOrRelation:
             The additional hostnames set by configuration already split by comma.
         """
         return [
-            x
-            for x in self._get_config_or_relation_data("additional-hostnames", "").split(",")
-            if x
+            hostname
+            for hostname in self._get_config_or_relation_data("additional-hostnames", "").split(
+                ","
+            )
+            if hostname
         ]
 
     @property
@@ -475,7 +477,7 @@ class NginxIngressCharm(CharmBase):
         field_names = [f'_{f.replace("-", "_")}' for f in REQUIRED_INGRESS_RELATION_FIELDS]
         return all(getattr(conf_or_rel, f) for f in field_names)
 
-    def _delete_unused_services(self, current_svc_names: List[str]):
+    def _delete_unused_services(self, current_svc_names: List[str]) -> None:
         """Delete services and ingresses that are no longer used.
 
         Args:
@@ -488,12 +490,12 @@ class NginxIngressCharm(CharmBase):
         all_services = api.list_namespaced_service(
             namespace=self._namespace, label_selector=created_by_label
         )
-        all_svc_names = [item.metadata.name for item in all_services.items]
-        unused_svc_names = [
+        all_svc_names = tuple(item.metadata.name for item in all_services.items)
+        unused_svc_names = tuple(
             svc_name
             for svc_name in all_svc_names
             if svc_name.replace("-service", "") not in current_svc_names
-        ]
+        )
         LOGGER.debug(
             "Checking for unused services. Configured: %s Found: %s Unused: %s",
             current_svc_names,
@@ -594,7 +596,7 @@ class NginxIngressCharm(CharmBase):
 
         body.spec.ingress_class_name = ingress_class
 
-    def _delete_unused_ingresses(self, current_svc_hostnames: List[str]):
+    def _delete_unused_ingresses(self, current_svc_hostnames: List[str]) -> None:
         """Delete ingresses that are no longer managed by nginx-ingress-integrator charm.
 
         Args:
@@ -606,10 +608,10 @@ class NginxIngressCharm(CharmBase):
         all_ingresses = api.list_namespaced_ingress(
             namespace=self._namespace, label_selector=created_by_label
         )
-        all_svc_hostnames = [ingress.spec.rules[0].host for ingress in all_ingresses.items]
-        unused_svc_hostnames = [
+        all_svc_hostnames = tuple(ingress.spec.rules[0].host for ingress in all_ingresses.items)
+        unused_svc_hostnames = tuple(
             hostname for hostname in all_svc_hostnames if hostname not in current_svc_hostnames
-        ]
+        )
         LOGGER.debug(
             "Checking for unused ingresses. Configured: %s Found: %s Unused: %s",
             current_svc_hostnames,

--- a/src/charm.py
+++ b/src/charm.py
@@ -494,7 +494,7 @@ class NginxIngressCharm(CharmBase):
             for svc_name in all_svc_names
             if svc_name.replace("-service", "") not in current_svc_names
         ]
-        LOGGER.info(
+        LOGGER.debug(
             "Checking for unused services. Configured: %s Found: %s Unused: %s",
             current_svc_names,
             all_svc_names,
@@ -610,7 +610,7 @@ class NginxIngressCharm(CharmBase):
         unused_svc_hostnames = [
             hostname for hostname in all_svc_hostnames if hostname not in current_svc_hostnames
         ]
-        LOGGER.info(
+        LOGGER.debug(
             "Checking for unused ingresses. Configured: %s Found: %s Unused: %s",
             current_svc_hostnames,
             all_svc_hostnames,
@@ -803,7 +803,6 @@ class NginxIngressCharm(CharmBase):
         # We only want to do anything here if we're the leader to avoid
         # collision if we've scaled out this application.
         svc_names = [conf_or_rel._service_name for conf_or_rel in self._all_config_or_relations]
-        print(svc_names)
         if self.unit.is_leader() and any(svc_names):
             try:
                 self._define_services()

--- a/src/charm.py
+++ b/src/charm.py
@@ -2,6 +2,8 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+# pylint: disable=protected-access,too-few-public-methods
+
 """Nginx-ingress-integrator charm file."""
 
 import logging
@@ -704,7 +706,12 @@ class NginxIngressCharm(CharmBase):
                 # Ensure that the exact same route for this route was not yet defined.
                 defined_paths = ingress_paths[rule.host]
                 for path in rule.http.paths:
-                    duplicate_paths = list(filter(lambda p: p.path == path.path, defined_paths))
+                    duplicate_paths = list(
+                        filter(
+                            lambda p: p.path == path.path,  # pylint: disable=cell-var-from-loop
+                            defined_paths,
+                        )
+                    )
                     if duplicate_paths:
                         LOGGER.error(
                             "Duplicate routes found:\nFirst route: %s\nSecond route: %s",
@@ -803,22 +810,20 @@ class NginxIngressCharm(CharmBase):
             )
 
     def _delete_unused_resources(self) -> None:
-        """Delete unused services and ingresses"""
+        """Delete unused services and ingresses."""
         svc_names = [conf_or_rel._service_name for conf_or_rel in self._all_config_or_relations]
         self._delete_unused_services(svc_names)
         svc_hostnames = [
             conf_or_rel._service_hostname for conf_or_rel in self._all_config_or_relations
         ]
         all_additional_hostnames = [
-            conf_or_rel._additional_hostnames
-            for conf_or_rel in self._all_config_or_relations
+            conf_or_rel._additional_hostnames for conf_or_rel in self._all_config_or_relations
         ]
         for additional_hostname in all_additional_hostnames:
             svc_hostnames.extend(additional_hostname)
         self._delete_unused_ingresses(svc_hostnames)
 
-
-    def _on_config_changed(self, event):
+    def _on_config_changed(self, _):
         """Handle the config changed event."""
         msg = ""
         # We only want to do anything here if we're the leader to avoid

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+# pylint: disable=import-error,consider-using-with
+
 """This code snippet is used to be loaded into any-charm which is used for integration tests."""
 import os
 import pathlib
@@ -56,11 +58,11 @@ class AnyCharm(AnyCharmBase):
         # We create a pid file to avoid concurrent executions of the http server
         pid_file = pathlib.Path("/tmp/any.pid")
         if pid_file.exists():
-            os.kill(int(pid_file.read_text()), signal.SIGKILL)
+            os.kill(int(pid_file.read_text(encoding="utf8")), signal.SIGKILL)
             pid_file.unlink()
-        p = subprocess.Popen(
+        proc_http = subprocess.Popen(
             ["python3", "-m", "http.server", "-d", www_dir, str(port)],
             start_new_session=True,
         )
-        pid_file.write_text(str(p.pid))
+        pid_file.write_text(str(proc_http.pid), encoding="utf8")
         return port

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -10,8 +10,8 @@ import signal
 import subprocess
 from typing import Dict
 
-from any_charm_base import AnyCharmBase
-from ingress import IngressRequires
+from any_charm_base import AnyCharmBase  # type: ignore[import]
+from ingress import IngressRequires  # type: ignore[import]
 
 INGRESS_CONFIG_ENVVAR = "ANYCHARM_INGRESS_CONFIG"
 

--- a/tests/integration/any_charm.py
+++ b/tests/integration/any_charm.py
@@ -14,6 +14,9 @@ from any_charm_base import AnyCharmBase  # type: ignore[import]
 from ingress import IngressRequires  # type: ignore[import]
 
 INGRESS_CONFIG_ENVVAR = "ANYCHARM_INGRESS_CONFIG"
+SVC_HOSTNAME = "service-hostname"
+SVC_NAME = "service-name"
+SVC_PORT = "service-port"
 
 
 class AnyCharm(AnyCharmBase):
@@ -53,7 +56,7 @@ class AnyCharm(AnyCharmBase):
         Returns:
             Returns true if all fields exist
         """
-        return "service-hostname" in rel and "service-name" in rel and "service-port" in rel
+        return all(key in rel for key in (SVC_HOSTNAME, SVC_NAME, SVC_PORT))
 
     def _has_app_data(self) -> bool:
         """Check for app in relation data
@@ -81,11 +84,11 @@ class AnyCharm(AnyCharmBase):
             rel = self.model.relations["ingress"][0].data[self.app]
             if self._has_required_fields(rel):
                 return {
-                    "service-hostname": rel["service-hostname"],
-                    "service-name": rel["service-name"],
-                    "service-port": rel["service-port"],
+                    SVC_HOSTNAME: rel[SVC_HOSTNAME],
+                    SVC_NAME: rel[SVC_NAME],
+                    SVC_PORT: rel[SVC_PORT],
                 }
-        return {"service-hostname": "any", "service-name": self.app.name, "service-port": 8080}
+        return {SVC_HOSTNAME: "any", SVC_NAME: self.app.name, SVC_PORT: 8080}
 
     @staticmethod
     def start_server(port: int = 8080):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -10,7 +10,7 @@ import subprocess  # nosec B404
 from pathlib import Path
 from typing import List
 
-import kubernetes
+import kubernetes  # type: ignore[import]
 import pytest_asyncio
 import yaml
 from ops.model import ActiveStatus, Application

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,9 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+# mypy: disable-error-code="union-attr"
+# pylint: disable=redefined-outer-name,subprocess-run-check,consider-using-with
+
 """General configuration module for integration tests."""
 import re
 import subprocess  # nosec B404
@@ -18,7 +21,7 @@ from pytest_operator.plugin import OpsTest
 @fixture(scope="module")
 def metadata():
     """Provide charm metadata."""
-    yield yaml.safe_load(Path("./metadata.yaml").read_text())
+    yield yaml.safe_load(Path("./metadata.yaml").read_text(encoding="utf8"))
 
 
 @fixture(scope="module")
@@ -45,11 +48,12 @@ async def app(ops_test: OpsTest, app_name: str):
     await ops_test.model.wait_for_idle(timeout=10 * 60)
 
     # Check that both ingress and hello-kubecon are active
-    assert ops_test.model.applications[app_name].units[0].workload_status == ActiveStatus.name
-    assert (
-        ops_test.model.applications[hello_kubecon_app_name].units[0].workload_status
-        == ActiveStatus.name
-    )
+    model_app = ops_test.model.applications[app_name]
+    app_status = model_app.units[0].workload_status
+    assert app_status == ActiveStatus.name  # type: ignore[has-type]
+    model_hello = ops_test.model.applications[hello_kubecon_app_name]
+    hello_status = model_hello.units[0].workload_status
+    assert hello_status == ActiveStatus.name  # type: ignore[has-type]
 
     # Add required relations
     await ops_test.model.add_relation(hello_kubecon_app_name, app_name)
@@ -65,15 +69,12 @@ async def ip_address_list(ops_test: OpsTest, app: Application):
     Example: Ingress IP(s): 127.0.0.1, Service IP(s): 10.152.183.84
     """
     # Reduce the update_status frequency until the cluster is deployed
+    status_message = app.units[0].workload_status_message  # type: ignore[attr-defined]
     async with ops_test.fast_forward():
-        await ops_test.model.block_until(
-            lambda: "Ingress IP(s)" in app.units[0].workload_status_message, timeout=100
-        )
+        await ops_test.model.block_until(lambda: "Ingress IP(s)" in status_message, timeout=100)
     ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
-    ip_address_list = re.findall(ip_regex, app.units[0].workload_status_message)
-    assert (
-        ip_address_list
-    ), f"could not find IP address in status message: {app.units[0].workload_status_message}"
+    ip_address_list = re.findall(ip_regex, status_message)
+    assert ip_address_list, f"could not find IP address in status message: {status_message}"
     yield ip_address_list
 
 
@@ -92,8 +93,9 @@ async def ingress_ip(ip_address_list: List):
 @pytest_asyncio.fixture(scope="module")
 async def app_url(ingress_ip: str):
     """Add to /etc/hosts."""
-    ps = subprocess.Popen(["echo", f"{ingress_ip} hello-kubecon"], stdout=subprocess.PIPE)  # nosec
-    subprocess.run(["sudo", "tee", "-a", "/etc/hosts"], stdin=ps.stdout)  # nosec
+    host_line = f"{ingress_ip} hello-kubecon"
+    proc_echo = subprocess.Popen(["echo", host_line], stdout=subprocess.PIPE)  # nosec
+    subprocess.run(["sudo", "tee", "-a", "/etc/hosts"], stdin=proc_echo.stdout)  # nosec
     yield "http://hello-kubecon"
 
 
@@ -102,7 +104,8 @@ async def app_url_modsec(ops_test: OpsTest, app_name: str, app_url: str):
     """Enable owasp-modsecurity-crs."""
     async with ops_test.fast_forward():
         await ops_test.juju("config", app_name, "owasp-modsecurity-crs=true")
-        await ops_test.model.wait_for_idle(status=ActiveStatus.name, timeout=60)
+        active = ActiveStatus.name  # type: ignore[has-type]
+        await ops_test.model.wait_for_idle(status=active, timeout=60)
     yield f"{app_url}/?search=../../passwords"
 
 
@@ -113,7 +116,8 @@ async def app_url_modsec_ignore(ops_test: OpsTest, app_name: str, app_url_modsec
     ignore_rule_cfg = f"owasp-modsecurity-custom-rules={ignore_rule}"
     async with ops_test.fast_forward():
         await ops_test.juju("config", app_name, ignore_rule_cfg)
-        await ops_test.model.wait_for_idle(status=ActiveStatus.name, timeout=60)
+        active = ActiveStatus.name  # type: ignore[has-type]
+        await ops_test.model.wait_for_idle(status=active, timeout=60)
     yield app_url_modsec
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+"""Integration test charm file."""
+
 import pytest
 import requests
 from ops.model import ActiveStatus, Application
@@ -14,7 +16,7 @@ async def test_active(app: Application):
     act: when the status is checked
     assert: then the workload status is active.
     """
-    assert app.units[0].workload_status == ActiveStatus.name
+    assert app.units[0].workload_status == ActiveStatus.name  # type: ignore[attr-defined,has-type]
 
 
 @pytest.mark.asyncio
@@ -26,7 +28,7 @@ async def test_service_reachable(service_ip: str):
     assert: then the response is HTTP 200 OK.
     """
     port = "8080"
-    response = requests.get(f"http://{service_ip}:{port}")
+    response = requests.get(f"http://{service_ip}:{port}", timeout=30)
 
     assert response.status_code == 200
 
@@ -39,7 +41,7 @@ async def test_ingress_reachable(app_url: str):
     act: when the dependent application is queried via the ingress
     assert: then the response is HTTP 200 OK.
     """
-    response = requests.get(app_url)
+    response = requests.get(app_url, timeout=30)
 
     assert response.status_code == 200
 
@@ -53,7 +55,7 @@ async def test_owasp_modsecurity_crs(app_url_modsec: str):
     act: when the dependent application is queried via the ingress with malicious request
     assert: then the response is HTTP 403 Forbidden for any request
     """
-    response = requests.get(app_url_modsec)
+    response = requests.get(app_url_modsec, timeout=30)
     assert response.status_code == 403
 
 
@@ -66,5 +68,5 @@ async def test_owasp_modsecurity_custom_rules(app_url_modsec_ignore: str):
     act: when the dependent application is queried via the ingress with malicious request
     assert: then the response is HTTP 200 OK.
     """
-    response = requests.get(app_url_modsec_ignore)
+    response = requests.get(app_url_modsec_ignore, timeout=30)
     assert response.status_code == 200

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -10,10 +10,11 @@ import json
 from pathlib import Path
 from typing import List
 
-import kubernetes
+import kubernetes  # type: ignore[import]
 import pytest
 import pytest_asyncio
 import requests
+from ops.model import Model
 from pytest_operator.plugin import OpsTest
 
 from charm import CREATED_BY_LABEL
@@ -40,6 +41,7 @@ async def build_and_deploy(ops_test: OpsTest, run_action):
         "ingress.py": ingress_lib,
         "any_charm.py": any_charm_script,
     }
+    assert isinstance(ops_test.model, Model)
 
     async def build_and_deploy_ingress():
         charm = await ops_test.build_charm(".")

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -14,7 +14,6 @@ import kubernetes  # type: ignore[import]
 import pytest
 import pytest_asyncio
 import requests
-from ops.model import Model
 from pytest_operator.plugin import OpsTest
 
 from charm import CREATED_BY_LABEL
@@ -41,11 +40,10 @@ async def build_and_deploy(ops_test: OpsTest, run_action):
         "ingress.py": ingress_lib,
         "any_charm.py": any_charm_script,
     }
-    assert isinstance(ops_test.model, Model)
 
     async def build_and_deploy_ingress():
         charm = await ops_test.build_charm(".")
-        return await ops_test.model.deploy(
+        return await ops_test.model.deploy(  # type: ignore[union-attr]
             str(charm), application_name="ingress", series="focal", trust=True
         )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -566,8 +566,8 @@ class TestCharm(unittest.TestCase):
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
         self.assertEqual(conf_or_rel._session_cookie_max_age, "3688")
 
-    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
-    @patch("charm.NginxIngressCharm._delete_unused_services")
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
+    @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._define_ingress")
@@ -1362,8 +1362,8 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         self.assertEqual(0, len(self.harness.charm.model.relations["ingress"]))
 
-    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
-    @patch("charm.NginxIngressCharm._delete_unused_services")
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
+    @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._remove_ingress")
@@ -1449,8 +1449,8 @@ class TestCharmMultipleRelations(unittest.TestCase):
             namespace=self.harness.charm._namespace,
         )
 
-    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
-    @patch("charm.NginxIngressCharm._delete_unused_services")
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
+    @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._remove_service")
@@ -1563,8 +1563,8 @@ class TestCharmMultipleRelations(unittest.TestCase):
             self.harness.charm._namespace,
         )
 
-    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
-    @patch("charm.NginxIngressCharm._delete_unused_services")
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
+    @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._remove_service")
@@ -1740,8 +1740,8 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         self.assertEqual(result, expected_result)
 
-    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
-    @patch("charm.NginxIngressCharm._delete_unused_services")
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
+    @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._remove_service")
@@ -1863,8 +1863,8 @@ class TestCharmMultipleRelations(unittest.TestCase):
             body=conf_or_rels[1]._get_k8s_ingress(),
         )
 
-    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
-    @patch("charm.NginxIngressCharm._delete_unused_services")
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
+    @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._define_ingress")
@@ -1936,8 +1936,8 @@ class TestCharmMultipleRelations(unittest.TestCase):
         expected_status = ActiveStatus("Service IP(s): 10.0.1.12")
         self.assertEqual(expected_status, self.harness.charm.unit.status)
 
-    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
-    @patch("charm.NginxIngressCharm._delete_unused_services")
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
+    @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._define_ingress")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -534,7 +534,7 @@ class TestCharm(unittest.TestCase):
             )
         ]
         mock_ingresses = _networking_v1_api.return_value.list_namespaced_ingress.return_value
-        mock_ingresses.items = [mock_ingress,mock_ingress_additional1,mock_ingress_additional2]
+        mock_ingresses.items = [mock_ingress, mock_ingress_additional1, mock_ingress_additional2]
         self.harness.update_config({"service-hostname": "foo.local"})
         self.assertTrue(
             self.harness.charm.unit.status,
@@ -542,7 +542,6 @@ class TestCharm(unittest.TestCase):
         )
         expected = self.harness.charm._ingress_name("to-be-removed.local")
         _remove_ingress.assert_called_once_with(expected)
-
 
     def test_session_cookie_max_age(self):
         """Test the session-cookie-max-age property."""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+
 import unittest
 from unittest import mock
 from unittest.mock import MagicMock, patch

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import unittest
-from typing import List
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -1719,6 +1718,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         self.assertEqual(result, expected_result)
 
+    @patch("charm._report_interval_count")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm.k8s_auth")
     @patch("charm.NginxIngressCharm._define_ingress")
@@ -1733,6 +1733,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_define_ingress,
         mock_k8s_auth,
         mock_service_ips,
+        _report_interval_count,
     ):
         """
         arrange: given the harnessed charm
@@ -1744,7 +1745,9 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_items.items = []
         mock_api.list_namespaced_ingress.return_value = mock_items
 
-        expected_result: List = []
+        expected_result: list = []
+
+        _report_interval_count.return_value = 1
 
         result = NginxIngressCharm._report_ingress_ips(NginxIngressCharm)  # type: ignore[arg-type]
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -424,7 +424,7 @@ class TestCharm(unittest.TestCase):
         """
         arrange: existing ingress not used anymore
         act: set service-name by configuration and no additional-hostnames
-        assert: Status is active with appropriate message and _remove_ingress is called once with right parameter
+        assert: Status is active and _remove_ingress is called once with right parameter
         """
         self.harness.set_leader(True)
         _report_ingress_ips.return_value = ["10.0.1.12"]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1699,10 +1699,12 @@ class TestCharmMultipleRelations(unittest.TestCase):
         an ingress IP is found.
         """
         mock_k8s_api.return_value = mock_api
+
         def get_item_lb(id):
-                mock_ip = mock.Mock()
-                mock_ip.ip = "127.0.0.1"
-                return mock_ip
+            mock_ip = mock.Mock()
+            mock_ip.ip = "127.0.0.1"
+            return mock_ip
+
         mock_ingress = MagicMock()
         mock_ingress.status.load_balancer.ingress.__getitem__.side_effect = get_item_lb
         mock_items = MagicMock()
@@ -1736,10 +1738,6 @@ class TestCharmMultipleRelations(unittest.TestCase):
         assert: this test will check that the charm will return a null value if
         an ingress IP is not found.
         """
-
-        #mock_list_ingress = mock_api.return_value.list_namespaced_ingress
-        #mock_list_ingress.return_value.items = []
-
         mock_k8s_api.return_value = mock_api
         mock_items = MagicMock()
         mock_items.items = []

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -20,6 +20,8 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
+    @patch("charm.NginxIngressCharm._delete_unused_services")
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._define_ingress")
@@ -30,6 +32,8 @@ class TestCharm(unittest.TestCase):
         _define_ingress,
         _report_service_ips,
         _report_ingress_ips,
+        _delete_unused_services,
+        _delete_unused_ingresses,
     ):
         """
         arrange: given the harnessed charm
@@ -413,12 +417,20 @@ class TestCharm(unittest.TestCase):
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
         self.assertEqual(conf_or_rel._session_cookie_max_age, "3688")
 
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
+    @patch("charm.NginxIngressCharm._delete_unused_services")
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._define_ingress")
     @patch("charm.NginxIngressCharm._define_services")
     def test_tls_secret_name(
-        self, mock_def_svc, mock_def_ingress, mock_report_ips, mock_ingress_ips
+        self,
+        mock_def_svc,
+        mock_def_ingress,
+        mock_report_ips,
+        mock_ingress_ips,
+        _delete_unused_ingresses,
+        _delete_unused_services,
     ):
         """
         arrange: given the harnessed charm
@@ -1201,13 +1213,22 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         self.assertEqual(0, len(self.harness.charm.model.relations["ingress"]))
 
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
+    @patch("charm.NginxIngressCharm._delete_unused_services")
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._remove_ingress")
     @patch("charm.NginxIngressCharm._define_ingress")
     @patch("charm._core_v1_api")
     def test_services_for_multiple_relations(
-        self, mock_api, mock_define_ingress, mock_remove_ingress, mock_report_ips, mock_ingress_ips
+        self,
+        mock_api,
+        mock_define_ingress,
+        mock_remove_ingress,
+        mock_report_ips,
+        mock_ingress_ips,
+        _delete_unused_services,
+        _delete_unused_ingresses,
     ):
         """
         arrange: given the harnessed charm
@@ -1279,13 +1300,22 @@ class TestCharmMultipleRelations(unittest.TestCase):
             namespace=self.harness.charm._namespace,
         )
 
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
+    @patch("charm.NginxIngressCharm._delete_unused_services")
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._remove_service")
     @patch("charm.NginxIngressCharm._define_service")
     @patch("charm._networking_v1_api")
     def test_ingresses_for_multiple_relations_same_hostname(
-        self, mock_api, mock_define_service, mock_remove_service, mock_report_ips, mock_ingress_ips
+        self,
+        mock_api,
+        mock_define_service,
+        mock_remove_service,
+        mock_report_ips,
+        mock_ingress_ips,
+        _delete_unused_services,
+        _delete_unused_ingresses,
     ):
         """
         arrange: given the harnessed charm
@@ -1384,13 +1414,22 @@ class TestCharmMultipleRelations(unittest.TestCase):
             self.harness.charm._namespace,
         )
 
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
+    @patch("charm.NginxIngressCharm._delete_unused_services")
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._remove_service")
     @patch("charm.NginxIngressCharm._define_service")
     @patch("charm._networking_v1_api")
     def test_ingresses_for_multiple_relations_different_hostnames(
-        self, mock_api, mock_define_service, mock_remove_service, mock_report_ips, mock_ingress_ips
+        self,
+        mock_api,
+        mock_define_service,
+        mock_remove_service,
+        mock_report_ips,
+        mock_ingress_ips,
+        _delete_unused_services,
+        _delete_unused_ingresses,
     ):
         """
         arrange: given the harnessed charm
@@ -1552,13 +1591,22 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         self.assertEqual(result, expected_result)
 
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
+    @patch("charm.NginxIngressCharm._delete_unused_services")
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._remove_service")
     @patch("charm.NginxIngressCharm._define_service")
     @patch("charm._networking_v1_api")
     def test_ingress_multiple_relations_additional_hostnames(
-        self, mock_api, mock_define_service, mock_remove_service, mock_report_ips, mock_ingress_ips
+        self,
+        mock_api,
+        mock_define_service,
+        mock_remove_service,
+        mock_report_ips,
+        mock_ingress_ips,
+        _delete_unused_services,
+        _delete_unused_ingresses,
     ):
         """
         arrange: given the harnessed charm
@@ -1666,13 +1714,22 @@ class TestCharmMultipleRelations(unittest.TestCase):
             body=conf_or_rels[1]._get_k8s_ingress(),
         )
 
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
+    @patch("charm.NginxIngressCharm._delete_unused_services")
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._define_ingress")
     @patch("charm.NginxIngressCharm._define_service")
     @patch("charm._networking_v1_api")
     def test_ingresses_for_multiple_relations_blocked(
-        self, mock_api, mock_define_service, mock_define_ingress, mock_report_ips, mock_ingress_ips
+        self,
+        mock_api,
+        mock_define_service,
+        mock_define_ingress,
+        mock_report_ips,
+        mock_ingress_ips,
+        _delete_unused_services,
+        _delete_unused_ingresses,
     ):
         """
         arrange: given the harnessed charm
@@ -1730,12 +1787,20 @@ class TestCharmMultipleRelations(unittest.TestCase):
         expected_status = ActiveStatus("Service IP(s): 10.0.1.12")
         self.assertEqual(expected_status, self.harness.charm.unit.status)
 
+    @patch("charm.NginxIngressCharm._delete_unused_ingresses")
+    @patch("charm.NginxIngressCharm._delete_unused_services")
     @patch("charm.NginxIngressCharm._report_ingress_ips")
     @patch("charm.NginxIngressCharm._report_service_ips")
     @patch("charm.NginxIngressCharm._define_ingress")
     @patch("charm.NginxIngressCharm._define_service")
     def test_missing_relation_data(
-        self, mock_define_service, mock_define_ingress, mock_report_ips, mock_ingress_ips
+        self,
+        mock_define_service,
+        mock_define_ingress,
+        mock_report_ips,
+        mock_ingress_ips,
+        _delete_unused_services,
+        _delete_unused_ingresses,
     ):
         """Test for handling missing relation data."""
         # Setting the leader to True will allow us to test the Ingress creation.

--- a/tests/unit/test_library_ingress.py
+++ b/tests/unit/test_library_ingress.py
@@ -3,6 +3,7 @@
 
 import itertools
 import unittest
+from typing import Dict
 
 import yaml
 from charms.nginx_ingress_integrator.v0.ingress import (  # type: ignore[import]
@@ -33,7 +34,7 @@ class TestCharmInit(unittest.TestCase):
         act: when the charm is constructed with the configuration
         assert: then the default value is set.
         """
-        config_dict: dict[str, str] = {}
+        config_dict: Dict[str, str] = {}
 
         class CharmWithConfigDict(NginxIngressConsumerCharm):
             def __init__(self, *args):

--- a/tests/unit/test_library_ingress.py
+++ b/tests/unit/test_library_ingress.py
@@ -5,7 +5,7 @@ import itertools
 import unittest
 
 import yaml
-from charms.nginx_ingress_integrator.v0.ingress import (
+from charms.nginx_ingress_integrator.v0.ingress import (  # type: ignore[import]
     OPTIONAL_INGRESS_RELATION_FIELDS,
     RELATION_INTERFACES_MAPPINGS,
     REQUIRED_INGRESS_RELATION_FIELDS,
@@ -33,7 +33,7 @@ class TestCharmInit(unittest.TestCase):
         act: when the charm is constructed with the configuration
         assert: then the default value is set.
         """
-        config_dict = {}
+        config_dict: dict[str, str] = {}
 
         class CharmWithConfigDict(NginxIngressConsumerCharm):
             def __init__(self, *args):
@@ -60,7 +60,7 @@ class TestCharmInit(unittest.TestCase):
             def __init__(self, *args):
                 super().__init__(*args, config_dict=config_dict)
 
-        self.harness = Harness(CharmWithConfigDict, meta=META)
+        self.harness = Harness(CharmWithConfigDict, meta=META)  # type: ignore[arg-type]
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
@@ -90,7 +90,7 @@ class TestCharmInit(unittest.TestCase):
             def __init__(self, *args):
                 super().__init__(*args, config_dict=config_dict)
 
-        self.harness = Harness(CharmWithConfigDict, meta=META)
+        self.harness = Harness(CharmWithConfigDict, meta=META)  # type: ignore[arg-type]
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
@@ -129,7 +129,7 @@ class TestCharmInit(unittest.TestCase):
             def __init__(self, *args):
                 super().__init__(*args, config_dict=config_dict)
 
-        self.harness = Harness(CharmWithConfigDict, meta=META)
+        self.harness = Harness(CharmWithConfigDict, meta=META)  # type: ignore[arg-type]
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 

--- a/tests/unit/test_library_ingress.py
+++ b/tests/unit/test_library_ingress.py
@@ -61,6 +61,7 @@ class TestCharmInit(unittest.TestCase):
             def __init__(self, *args):
                 super().__init__(*args, config_dict=config_dict)
 
+        # CharmType in Harness should be changed to fix this error
         self.harness = Harness(CharmWithConfigDict, meta=META)  # type: ignore[arg-type]
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()

--- a/tox.ini
+++ b/tox.ini
@@ -38,27 +38,36 @@ deps =
     codespell
     flake8<6.0.0
     flake8-builtins
-    flake8-copyright
+    flake8-copyright<6.0.0
     flake8-docstrings>=1.6.0
-    flake8-docstrings-complete
-    flake8-test-docs
+    flake8-docstrings-complete>=1.0.3
+    flake8-test-docs>=1.0
     isort
+    mypy
     pep8-naming
-    pydocstyle
+    pydocstyle>=2.10
     pylint
     pyproject-flake8<6.0.0
+    pytest
+    pytest-asyncio
+    pytest-operator
+    requests
+    types-PyYAML
+    types-requests
+    -r{toxinidir}/requirements.txt
 commands =
+    pydocstyle {[vars]src_path}
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
-    pydocstyle {[vars]all_path}
-    pylint {[vars]src_path} --disable=F0401,R0903,R0914,W0212,W0511,W0613,W0640
     codespell {toxinidir} --skip {toxinidir}/.git --skip {toxinidir}/.tox \
       --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
       --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
     # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
+    pflake8 {[vars]all_path} --ignore=W503
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
+    mypy {[vars]all_path}
+    pylint {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
Fix #4 

This PR:
- Add a mechanism that for every event, checks if there are unused services or ingress and delete them. 
This is done by:
1) getting all services/ingress resources with the label "app.juju.is/created-by=".
2) getting all services/ingress resources from config or relations 
3) Each service/ingress resource that is not in the list mentioned above is deleted.
- Add unit and integration tests
- Add mypy checker and related fixes or disabled types
- Change AnyCharm to get Ingress values from the relation, if exists. The default values were set in the _\_init_\_ and since charm is a stateless application, every event was initializing the charm and recreating the ingress with the default values. Reference [here](https://juju.is/docs/sdk/create-a-minimal-kubernetes-charm#heading--define-the-charm-initialisation-and-application-services).

Findings that will be addressed in further PRs:
- Custom label for NGINX charm (to be confirmed)
- Refactoring of unit tests (ISD-417)
- Refactoring of Type hints (ISD-422)