### PR TITLE
Adding custom labels

### DIFF
--- a/docs/Tutorials/adding-ingress-relation.md
+++ b/docs/Tutorials/adding-ingress-relation.md
@@ -121,6 +121,7 @@ We can also take a look at the configured ingress resource as follows (with samp
 $ microk8s kubectl describe ingress -n ingress-test
 Name:             my-charm-ingress
 Labels:           app.juju.is/created-by=nginx-ingress-integrator
+                  nginx-ingress-integrator.charm.juju.is/managed-by=nginx-ingress-integrator
 Namespace:        ingress-test
 Address:          127.0.0.1
 Ingress Class:    public

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,7 +28,7 @@ BOOLEAN_CONFIG_FIELDS = ["rewrite-enabled"]
 # Juju defines the value of this label.
 # It has the same value as the label "app.kubernetes.io/name"
 # set in the service account associated with the application.
-CREATED_BY_LABEL = "created-by"
+CREATED_BY_LABEL = "nginx-ingress-integrator.charm.juju.is/managed-by"
 REPORT_INTERVAL_COUNT = 100
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -25,9 +25,8 @@ from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 LOGGER = logging.getLogger(__name__)
 _INGRESS_SUB_REGEX = re.compile("[^0-9a-zA-Z]")
 BOOLEAN_CONFIG_FIELDS = ["rewrite-enabled"]
-# Juju defines the value of this label.
-# It has the same value as the label "app.kubernetes.io/name"
-# set in the service account associated with the application.
+# We set this value to be unique for this deployed juju application
+# so we can use it to identify resources created by this charm
 CREATED_BY_LABEL = "nginx-ingress-integrator.charm.juju.is/managed-by"
 REPORT_INTERVAL_COUNT = 100
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,7 +28,7 @@ BOOLEAN_CONFIG_FIELDS = ["rewrite-enabled"]
 # Juju defines the value of this label.
 # It has the same value as the label "app.kubernetes.io/name"
 # set in the service account associated with the application.
-CREATED_BY_LABEL = "Ingress-label"
+CREATED_BY_LABEL = "created-by"
 REPORT_INTERVAL_COUNT = 100
 
 
@@ -280,7 +280,7 @@ class _ConfigOrRelation:
         """Return the whitelist-source-range config option."""
         return self._get_config("whitelist-source-range")
 
-    def _get_k8s_service(self, label: str) -> Any:
+    def _get_k8s_service(self, label: str) -> kubernetes.client.V1Service:
         """Get a K8s service definition.
 
         Args:
@@ -304,7 +304,7 @@ class _ConfigOrRelation:
             ),
         )
 
-    def _get_k8s_ingress(self, label: str) -> Any:
+    def _get_k8s_ingress(self, label: str) -> kubernetes.client.V1Ingress:
         """Get a K8s ingress definition.
 
         Args:

--- a/src/charm.py
+++ b/src/charm.py
@@ -28,7 +28,7 @@ BOOLEAN_CONFIG_FIELDS = ["rewrite-enabled"]
 # Juju defines the value of this label.
 # It has the same value as the label "app.kubernetes.io/name"
 # set in the service account associated with the application.
-CREATED_BY_LABEL = "app.juju.is/created-by="
+CREATED_BY_LABEL = "Ingress-label"
 REPORT_INTERVAL_COUNT = 100
 
 
@@ -280,12 +280,18 @@ class _ConfigOrRelation:
         """Return the whitelist-source-range config option."""
         return self._get_config("whitelist-source-range")
 
-    def _get_k8s_service(self) -> Any:
-        """Get a K8s service definition."""
+    def _get_k8s_service(self, label: str) -> Any:
+        """Get a K8s service definition.
+
+        Args:
+            label: Custom label assigned to every service.
+        """
         return kubernetes.client.V1Service(
             api_version="v1",
             kind="Service",
-            metadata=kubernetes.client.V1ObjectMeta(name=self._k8s_service_name),
+            metadata=kubernetes.client.V1ObjectMeta(
+                name=self._k8s_service_name, labels={CREATED_BY_LABEL: label}
+            ),
             spec=kubernetes.client.V1ServiceSpec(
                 selector={"app.kubernetes.io/name": self._service_name},
                 ports=[
@@ -298,8 +304,12 @@ class _ConfigOrRelation:
             ),
         )
 
-    def _get_k8s_ingress(self) -> Any:
-        """Get a K8s ingress definition."""
+    def _get_k8s_ingress(self, label: str) -> Any:
+        """Get a K8s ingress definition.
+
+        Args:
+            label: Custom label assigned to every ingress.
+        """
         ingress_paths = [
             kubernetes.client.V1HTTPIngressPath(
                 path=path,
@@ -373,8 +383,7 @@ class _ConfigOrRelation:
             api_version="networking.k8s.io/v1",
             kind="Ingress",
             metadata=kubernetes.client.V1ObjectMeta(
-                name=self._ingress_name,
-                annotations=annotations,
+                name=self._ingress_name, annotations=annotations, labels={CREATED_BY_LABEL: label}
             ),
             spec=spec,
         )
@@ -488,9 +497,6 @@ class NginxIngressCharm(CharmBase):
         field_names = [f'_{f.replace("-", "_")}' for f in REQUIRED_INGRESS_RELATION_FIELDS]
         return all(getattr(conf_or_rel, f) for f in field_names)
 
-    def _get_created_label(self) -> str:
-        return f"{CREATED_BY_LABEL}{self.app.name}"
-
     def _delete_unused_services(self, current_svc_names: List[str]) -> None:
         """Delete services and ingresses that are no longer used.
 
@@ -500,7 +506,7 @@ class NginxIngressCharm(CharmBase):
         """
         api = self._core_v1_api()
         all_services = api.list_namespaced_service(  # type: ignore[attr-defined]
-            namespace=self._namespace, label_selector=self._get_created_label()
+            namespace=self._namespace, label_selector=f"{CREATED_BY_LABEL}={self.app.name}"
         )
         all_svc_names = tuple(item.metadata.name for item in all_services.items)
         unused_svc_names = tuple(
@@ -537,7 +543,7 @@ class NginxIngressCharm(CharmBase):
     def _define_service(self, conf_or_rel: _ConfigOrRelation) -> None:
         """Create or update a service in kubernetes."""
         api = self._core_v1_api()
-        body = conf_or_rel._get_k8s_service()
+        body = conf_or_rel._get_k8s_service(self.app.name)
         services = api.list_namespaced_service(  # type: ignore[attr-defined]
             namespace=self._namespace
         )
@@ -618,7 +624,7 @@ class NginxIngressCharm(CharmBase):
         """
         api = self._networking_v1_api()
         all_ingresses = api.list_namespaced_ingress(  # type: ignore[attr-defined]
-            namespace=self._namespace, label_selector=self._get_created_label()
+            namespace=self._namespace, label_selector=f"{CREATED_BY_LABEL}={self.app.name}"
         )
         all_svc_hostnames = tuple(ingress.spec.rules[0].host for ingress in all_ingresses.items)
         unused_svc_hostnames = tuple(
@@ -655,7 +661,9 @@ class NginxIngressCharm(CharmBase):
         # Filter out any cases in which we don't have data set (e.g.: missing relation data)
         config_or_relations = filter(self._has_required_fields, config_or_relations)
 
-        ingresses = [conf_or_rel._get_k8s_ingress() for conf_or_rel in config_or_relations]
+        ingresses = [
+            conf_or_rel._get_k8s_ingress(self.app.name) for conf_or_rel in config_or_relations
+        ]
 
         ingresses = self._process_ingresses(ingresses)
 
@@ -665,7 +673,7 @@ class NginxIngressCharm(CharmBase):
             conf_or_rel = _ConfigOrRelation(
                 self.model, self.config, excluded_relation, self._multiple_relations
             )
-            excluded_ingress = conf_or_rel._get_k8s_ingress()
+            excluded_ingress = conf_or_rel._get_k8s_ingress(self.app.name)
 
             # The Kubernetes Ingress Resources we're creating only has 1 rule per hostname.
             used_hostnames = [ingress.spec.rules[0].host for ingress in ingresses]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,7 +72,6 @@ async def ip_address_list(ops_test: OpsTest, app: Application):
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(status="active")
-    # time.sleep(100)
     status_message = app.units[0].workload_status_message  # type: ignore[attr-defined]
     ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
     ip_address_list = re.findall(ip_regex, status_message)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,7 +7,6 @@
 """General configuration module for integration tests."""
 import re
 import subprocess  # nosec B404
-import time
 from pathlib import Path
 from typing import List
 
@@ -72,7 +71,7 @@ async def ip_address_list(ops_test: OpsTest, app: Application):
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(status="active")
-    time.sleep(100)
+    # time.sleep(100)
     status_message = app.units[0].workload_status_message  # type: ignore[attr-defined]
     ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
     ip_address_list = re.findall(ip_regex, status_message)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,6 +36,7 @@ async def app(ops_test: OpsTest, app_name: str):
 
     Builds the charm and deploys it and a charm that depends on it.
     """
+    print("LETS GO")
     # Deploy relations first to speed up overall execution
     hello_kubecon_app_name = "hello-kubecon"
     await ops_test.model.deploy(hello_kubecon_app_name)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -147,7 +147,7 @@ def wait_for_ingress(ops_test: OpsTest):
             lambda: ingress_name
             in [
                 ingress.metadata.name
-                for ingress in kube.list_namespaced_ingress(ops_test.model.name).items
+                for ingress in kube.list_namespaced_ingress(ops_test.model_name).items
             ],
             wait_period=5,
             timeout=10 * 60,
@@ -162,7 +162,7 @@ def get_ingress_annotation(ops_test: OpsTest):
     assert ops_test.model
     kubernetes.config.load_kube_config()
     kube = kubernetes.client.NetworkingV1Api()
-    model_name = ops_test.model.name
+    model_name = ops_test.model_name
 
     def _get_ingress_annotation(ingress_name: str):
         return kube.read_namespaced_ingress(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@
 """General configuration module for integration tests."""
 import re
 import subprocess  # nosec B404
+import time
 from pathlib import Path
 from typing import List
 
@@ -71,6 +72,7 @@ async def ip_address_list(ops_test: OpsTest, app: Application):
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(status="active")
+    time.sleep(100)
     status_message = app.units[0].workload_status_message  # type: ignore[attr-defined]
     ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
     ip_address_list = re.findall(ip_regex, status_message)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -70,8 +70,8 @@ async def ip_address_list(ops_test: OpsTest, app: Application):
     """
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():
-        status_message = app.units[0].workload_status_message  # type: ignore[attr-defined]
         await ops_test.model.wait_for_idle(status="active")
+    status_message = app.units[0].workload_status_message  # type: ignore[attr-defined]
     ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
     ip_address_list = re.findall(ip_regex, status_message)
     assert ip_address_list, f"could not find IP address in status message: {status_message}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -57,7 +57,7 @@ async def app(ops_test: OpsTest, app_name: str):
 
     # Add required relations
     await ops_test.model.add_relation(hello_kubecon_app_name, app_name)
-    await ops_test.model.wait_for_idle(timeout=10 * 60)
+    await ops_test.model.wait_for_idle(timeout=10 * 60, status=ActiveStatus.name)
 
     yield application
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -71,9 +71,7 @@ async def ip_address_list(ops_test: OpsTest, app: Application):
     # Reduce the update_status frequency until the cluster is deployed
     async with ops_test.fast_forward():
         status_message = app.units[0].workload_status_message  # type: ignore[attr-defined]
-        await ops_test.model.block_until(
-            lambda: "Ingress IP(s)" in status_message, timeout=15 * 600
-        )
+        await ops_test.model.wait_for_idle(status="active")
     ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
     ip_address_list = re.findall(ip_regex, status_message)
     assert ip_address_list, f"could not find IP address in status message: {status_message}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,7 +36,6 @@ async def app(ops_test: OpsTest, app_name: str):
 
     Builds the charm and deploys it and a charm that depends on it.
     """
-    print("LETS GO")
     # Deploy relations first to speed up overall execution
     hello_kubecon_app_name = "hello-kubecon"
     await ops_test.model.deploy(hello_kubecon_app_name)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,7 +72,7 @@ async def ip_address_list(ops_test: OpsTest, app: Application):
     async with ops_test.fast_forward():
         status_message = app.units[0].workload_status_message  # type: ignore[attr-defined]
         await ops_test.model.block_until(
-            lambda: "Ingress IP(s)" in status_message, timeout=15 * 60
+            lambda: "Ingress IP(s)" in status_message, timeout=15 * 600
         )
     ip_regex = r"[0-9]+(?:\.[0-9]+){3}"
     ip_address_list = re.findall(ip_regex, status_message)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -57,8 +57,9 @@ async def app(ops_test: OpsTest, app_name: str):
 
     # Add required relations
     await ops_test.model.add_relation(hello_kubecon_app_name, app_name)
-    await ops_test.model.wait_for_idle(timeout=10 * 60, status=ActiveStatus.name)
-
+    await ops_test.model.wait_for_idle(
+        timeout=10 * 60, status=ActiveStatus.name  # type: ignore[has-type]
+    )
     yield application
 
 

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -101,7 +101,7 @@ async def test_delete_unused_ingresses(ops_test: OpsTest):
     kubernetes.config.load_kube_config()
     api_networking = kubernetes.client.NetworkingV1Api()
     assert isinstance(ops_test.model, Model)
-    model_name = ops_test.model.name
+    model_name = ops_test.model_name
     created_by_label = f"{CREATED_BY_LABEL}=ingress"
 
     def compare_svc_hostnames(expected: List[str]) -> bool:

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -105,7 +105,7 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
 
     # def compare_svc_hostnames(expected: List[str]) -> bool:
     all_ingresses = api_networking.list_namespaced_ingress(
-        namespace=model_name, label_selector=f"{CREATED_BY_LABEL}={INGRESS_APP_NAME}"
+        namespace=model_name
     )
 
     # func_result = compare_svc_hostnames(["any-service"])
@@ -139,8 +139,6 @@ async def test_delete_unused_services(ops_test: OpsTest, app_name):
         )
         return expected == [item.metadata.name for item in all_services.items]
 
-    func_result = compare_svc_names(["any-service"])
-    print(func_result)
     assert compare_svc_names(["any-service"])
     await ops_test.juju("config", INGRESS_APP_NAME, "service-name=new-name")
     await ops_test.model.wait_for_idle(status="active")

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -156,6 +156,7 @@ async def setup_new_hostname_and_port(ops_test, build_and_deploy, run_action, wa
     rpc_return = await run_action(
         ANY_APP_NAME, "rpc", method="start_server", kwargs=json.dumps({"port": NEW_PORT})
     )
+    print(rpc_return)
     assert rpc_return["return-code"] == 0 and json.loads(rpc_return["return"]) == NEW_PORT
     await run_action(
         ANY_APP_NAME,

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -92,7 +92,7 @@ async def anycharm_update_ingress_config_fixture(request, ops_test, run_action):
 
 
 @pytest.mark.usefixtures("build_and_deploy")
-async def test_delete_unused_ingresses(ops_test: OpsTest):
+async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
     """
     arrange: given charm has been built, deployed and related to a dependent application
     act: when the service-hostname is changed and when is back to previous value
@@ -102,11 +102,11 @@ async def test_delete_unused_ingresses(ops_test: OpsTest):
     api_networking = kubernetes.client.NetworkingV1Api()
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model_name
-    created_by_label = f"{CREATED_BY_LABEL}=ingress"
+    created_by_label = f"{CREATED_BY_LABEL}={app_name}"
 
     def compare_svc_hostnames(expected: List[str]) -> bool:
         all_ingresses = api_networking.list_namespaced_ingress(
-            namespace=model_name, label_selector=created_by_label
+            namespace=model_name, label_selector=f"{CREATED_BY_LABEL}={app_name}"
         )
         return expected == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
 
@@ -120,7 +120,7 @@ async def test_delete_unused_ingresses(ops_test: OpsTest):
 
 
 @pytest.mark.usefixtures("build_and_deploy")
-async def test_delete_unused_services(ops_test: OpsTest):
+async def test_delete_unused_services(ops_test: OpsTest, app_name):
     """
     arrange: given charm has been built, deployed and related to a dependent application
     act: when the service-name is changed and when is back to previous value
@@ -130,7 +130,7 @@ async def test_delete_unused_services(ops_test: OpsTest):
     api_core = kubernetes.client.CoreV1Api()
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model_name
-    created_by_label = f"{CREATED_BY_LABEL}=ingress"
+    created_by_label = f"{CREATED_BY_LABEL}={app_name}"
 
     def compare_svc_names(expected: List[str]) -> bool:
         all_services = api_core.list_namespaced_service(

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -156,7 +156,7 @@ async def setup_new_hostname_and_port(ops_test, build_and_deploy, run_action, wa
     rpc_return = await run_action(
         ANY_APP_NAME, "rpc", method="start_server", kwargs=json.dumps({"port": NEW_PORT})
     )
-    assert rpc_return["Code"] == '0' and json.loads(rpc_return["return"]) == NEW_PORT
+    assert rpc_return["Code"] == "0" and json.loads(rpc_return["return"]) == NEW_PORT
     await run_action(
         ANY_APP_NAME,
         "rpc",

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -156,8 +156,7 @@ async def setup_new_hostname_and_port(ops_test, build_and_deploy, run_action, wa
     rpc_return = await run_action(
         ANY_APP_NAME, "rpc", method="start_server", kwargs=json.dumps({"port": NEW_PORT})
     )
-    print(rpc_return)
-    assert rpc_return["return-code"] == 0 and json.loads(rpc_return["return"]) == NEW_PORT
+    assert rpc_return["Code"] == 0 and json.loads(rpc_return["return"]) == NEW_PORT
     await run_action(
         ANY_APP_NAME,
         "rpc",

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -102,7 +102,7 @@ async def test_delete_unused_ingresses(ops_test: OpsTest):
     api_networking = kubernetes.client.NetworkingV1Api()
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model.name
-    created_by_label = f"{CREATED_BY_LABEL}ingress"
+    created_by_label = f"{CREATED_BY_LABEL}=ingress"
 
     def compare_svc_hostnames(expected: List[str]) -> bool:
         all_ingresses = api_networking.list_namespaced_ingress(
@@ -130,7 +130,7 @@ async def test_delete_unused_services(ops_test: OpsTest):
     api_core = kubernetes.client.CoreV1Api()
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model.name
-    created_by_label = f"{CREATED_BY_LABEL}ingress"
+    created_by_label = f"{CREATED_BY_LABEL}=ingress"
 
     def compare_svc_names(expected: List[str]) -> bool:
         all_services = api_core.list_namespaced_service(

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -105,6 +105,7 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
 
     def compare_svc_hostnames(expected: List[str]) -> bool:
         all_ingresses = api_networking.list_namespaced_ingress(namespace=model_name)
+        print([ingress.spec.rules[0].host for ingress in all_ingresses.items])
         return expected == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
 
     assert compare_svc_hostnames(["any-service"])
@@ -127,14 +128,12 @@ async def test_delete_unused_services(ops_test: OpsTest, app_name):
     api_core = kubernetes.client.CoreV1Api()
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model_name
-    print(app_name)
     created_by_label = f"{CREATED_BY_LABEL}={INGRESS_APP_NAME}"
 
     def compare_svc_names(expected: List[str]) -> bool:
         all_services = api_core.list_namespaced_service(
             namespace=model_name, label_selector=created_by_label
         )
-        print([item.metadata.name for item in all_services.items])
         return expected == [item.metadata.name for item in all_services.items]
 
     assert compare_svc_names(["any-service"])

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -108,6 +108,7 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
             namespace=model_name, label_selector=f"{CREATED_BY_LABEL}={app_name}"
         )
         return expected == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
+
     func_result = compare_svc_hostnames(["any-service"])
     print(func_result)
     assert compare_svc_hostnames(["any"])
@@ -137,6 +138,7 @@ async def test_delete_unused_services(ops_test: OpsTest, app_name):
             namespace=model_name, label_selector=created_by_label
         )
         return expected == [item.metadata.name for item in all_services.items]
+
     func_result = compare_svc_names(["any-service"])
     print(func_result)
     assert compare_svc_names(["any-service"])

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -130,7 +130,8 @@ async def test_delete_unused_services(ops_test: OpsTest, app_name):
     api_core = kubernetes.client.CoreV1Api()
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model_name
-    created_by_label = f"{CREATED_BY_LABEL}={app_name}"
+    print(app_name)
+    created_by_label = f"app.juju.is/created-by={app_name}"
 
     def compare_svc_names(expected: List[str]) -> bool:
         all_services = api_core.list_namespaced_service(

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -131,7 +131,7 @@ async def test_delete_unused_services(ops_test: OpsTest, app_name):
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model_name
     print(app_name)
-    created_by_label = f"app.juju.is/created-by={app_name}"
+    created_by_label = f"{CREATED_BY_LABEL}={INGRESS_APP_NAME}"
 
     def compare_svc_names(expected: List[str]) -> bool:
         all_services = api_core.list_namespaced_service(

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -105,7 +105,6 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
 
     def compare_svc_hostnames(expected: List[str]) -> bool:
         all_ingresses = api_networking.list_namespaced_ingress(namespace=model_name)
-        print([ingress.spec.rules[0].host for ingress in all_ingresses.items])
         return expected == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
 
     assert compare_svc_hostnames(["any"])

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -105,7 +105,7 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
 
     # def compare_svc_hostnames(expected: List[str]) -> bool:
     all_ingresses = api_networking.list_namespaced_ingress(
-        namespace=model_name, label_selector=f"{CREATED_BY_LABEL}={app_name}"
+        namespace=model_name, label_selector=f"{CREATED_BY_LABEL}={INGRESS_APP_NAME}"
     )
 
     # func_result = compare_svc_hostnames(["any-service"])

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -134,6 +134,7 @@ async def test_delete_unused_services(ops_test: OpsTest, app_name):
         all_services = api_core.list_namespaced_service(
             namespace=model_name, label_selector=created_by_label
         )
+        print([item.metadata.name for item in all_services.items])
         return expected == [item.metadata.name for item in all_services.items]
 
     assert compare_svc_names(["any-service"])

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -108,7 +108,8 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
             namespace=model_name, label_selector=f"{CREATED_BY_LABEL}={app_name}"
         )
         return expected == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
-
+    func_result = compare_svc_hostnames(["any-service"])
+    print(func_result)
     assert compare_svc_hostnames(["any"])
     await ops_test.juju("config", INGRESS_APP_NAME, "service-hostname=new-name")
     await ops_test.model.wait_for_idle(status="active")
@@ -136,7 +137,8 @@ async def test_delete_unused_services(ops_test: OpsTest, app_name):
             namespace=model_name, label_selector=created_by_label
         )
         return expected == [item.metadata.name for item in all_services.items]
-
+    func_result = compare_svc_names(["any-service"])
+    print(func_result)
     assert compare_svc_names(["any-service"])
     await ops_test.juju("config", INGRESS_APP_NAME, "service-name=new-name")
     await ops_test.model.wait_for_idle(status="active")

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -156,7 +156,7 @@ async def setup_new_hostname_and_port(ops_test, build_and_deploy, run_action, wa
     rpc_return = await run_action(
         ANY_APP_NAME, "rpc", method="start_server", kwargs=json.dumps({"port": NEW_PORT})
     )
-    assert rpc_return["Code"] == 0 and json.loads(rpc_return["return"]) == NEW_PORT
+    assert rpc_return["Code"] == '0' and json.loads(rpc_return["return"]) == NEW_PORT
     await run_action(
         ANY_APP_NAME,
         "rpc",

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -103,21 +103,20 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model_name
 
-    def compare_svc_hostnames(expected: List[str]) -> bool:
-        all_ingresses = api_networking.list_namespaced_ingress(
-            namespace=model_name, label_selector=f"{CREATED_BY_LABEL}={app_name}"
-        )
-        return expected == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
+    # def compare_svc_hostnames(expected: List[str]) -> bool:
+    all_ingresses = api_networking.list_namespaced_ingress(
+        namespace=model_name, label_selector=f"{CREATED_BY_LABEL}={app_name}"
+    )
 
-    func_result = compare_svc_hostnames(["any-service"])
-    print(func_result)
-    assert compare_svc_hostnames(["any"])
+    # func_result = compare_svc_hostnames(["any-service"])
+    # print(func_result)
+    assert ["any-service"] == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
     await ops_test.juju("config", INGRESS_APP_NAME, "service-hostname=new-name")
     await ops_test.model.wait_for_idle(status="active")
-    assert compare_svc_hostnames(["new-name"])
+    # assert compare_svc_hostnames(["new-name"])
     await ops_test.juju("config", INGRESS_APP_NAME, "service-hostname=")
     await ops_test.model.wait_for_idle(status="active")
-    assert compare_svc_hostnames(["any"])
+    # assert compare_svc_hostnames(["any"])
 
 
 @pytest.mark.usefixtures("build_and_deploy")

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -129,7 +129,7 @@ async def test_delete_unused_services(ops_test: OpsTest):
     kubernetes.config.load_kube_config()
     api_core = kubernetes.client.CoreV1Api()
     assert isinstance(ops_test.model, Model)
-    model_name = ops_test.model.name
+    model_name = ops_test.model_name
     created_by_label = f"{CREATED_BY_LABEL}=ingress"
 
     def compare_svc_names(expected: List[str]) -> bool:
@@ -209,7 +209,7 @@ async def test_owasp_modsecurity_crs_relation(ops_test: OpsTest, run_action):
     kubernetes.config.load_kube_config()
     kube = kubernetes.client.NetworkingV1Api()
     assert isinstance(ops_test.model, Model)
-    model_name = ops_test.model.name
+    model_name = ops_test.model_name
 
     def get_ingress_annotation():
         return kube.read_namespaced_ingress(NEW_INGRESS, namespace=model_name).metadata.annotations

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -108,7 +108,7 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
         print([ingress.spec.rules[0].host for ingress in all_ingresses.items])
         return expected == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
 
-    assert compare_svc_hostnames(["any-service"])
+    assert compare_svc_hostnames(["any"])
     await ops_test.juju("config", INGRESS_APP_NAME, "service-hostname=new-name")
     await ops_test.model.wait_for_idle(status="active")
     assert compare_svc_hostnames(["new-name"])

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -102,7 +102,6 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
     api_networking = kubernetes.client.NetworkingV1Api()
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model_name
-    created_by_label = f"{CREATED_BY_LABEL}={app_name}"
 
     def compare_svc_hostnames(expected: List[str]) -> bool:
         all_ingresses = api_networking.list_namespaced_ingress(

--- a/tests/integration/test_relation.py
+++ b/tests/integration/test_relation.py
@@ -103,20 +103,17 @@ async def test_delete_unused_ingresses(ops_test: OpsTest, app_name: str):
     assert isinstance(ops_test.model, Model)
     model_name = ops_test.model_name
 
-    # def compare_svc_hostnames(expected: List[str]) -> bool:
-    all_ingresses = api_networking.list_namespaced_ingress(
-        namespace=model_name
-    )
+    def compare_svc_hostnames(expected: List[str]) -> bool:
+        all_ingresses = api_networking.list_namespaced_ingress(namespace=model_name)
+        return expected == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
 
-    # func_result = compare_svc_hostnames(["any-service"])
-    # print(func_result)
-    assert ["any-service"] == [ingress.spec.rules[0].host for ingress in all_ingresses.items]
+    assert compare_svc_hostnames(["any-service"])
     await ops_test.juju("config", INGRESS_APP_NAME, "service-hostname=new-name")
     await ops_test.model.wait_for_idle(status="active")
-    # assert compare_svc_hostnames(["new-name"])
+    assert compare_svc_hostnames(["new-name"])
     await ops_test.juju("config", INGRESS_APP_NAME, "service-hostname=")
     await ops_test.model.wait_for_idle(status="active")
-    # assert compare_svc_hostnames(["any"])
+    assert compare_svc_hostnames(["any"])
 
 
 @pytest.mark.usefixtures("build_and_deploy")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ import kubernetes.client  # type: ignore[import]
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
-from charm import NginxIngressCharm
+from charm import CREATED_BY_LABEL, NginxIngressCharm
 
 
 class TestCharm(unittest.TestCase):
@@ -211,7 +211,7 @@ class TestCharm(unittest.TestCase):
             },
         ]
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
-        result_dict = conf_or_rel._get_k8s_ingress().to_dict()
+        result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         self.assertEqual(result_dict["spec"]["rules"][0]["http"]["paths"], expected)
 
     def test_max_body_size(self):
@@ -287,7 +287,7 @@ class TestCharm(unittest.TestCase):
             }
         )
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
-        result_dict = conf_or_rel._get_k8s_ingress().to_dict()
+        result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
@@ -304,7 +304,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"owasp-modsecurity-custom-rules": custom_rule})
         self.assertEqual(conf_or_rel._owasp_modsecurity_crs, True)
         self.assertEqual(conf_or_rel._owasp_modsecurity_custom_rules, custom_rule)
-        result_dict = conf_or_rel._get_k8s_ingress().to_dict()
+        result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
             "nginx.ingress.kubernetes.io/enable-modsecurity": "true",
             "nginx.ingress.kubernetes.io/enable-owasp-modsecurity-crs": "true",
@@ -331,7 +331,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"owasp-modsecurity-custom-rules": custom_rule})
         self.assertEqual(conf_or_rel._owasp_modsecurity_crs, True)
         self.assertEqual(conf_or_rel._owasp_modsecurity_custom_rules, custom_rule)
-        result_dict = conf_or_rel._get_k8s_ingress().to_dict()
+        result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
             "nginx.ingress.kubernetes.io/enable-modsecurity": "true",
             "nginx.ingress.kubernetes.io/enable-owasp-modsecurity-crs": "true",
@@ -618,7 +618,8 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(conf_or_rel._tls_secret_name, "gunicorn-tls-new")
 
         mock_def_svc.assert_called_once()
-        base_ingress = conf_or_rel._get_k8s_ingress()
+        base_ingress = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name)
+        base_ingress.metadata.labels = None
 
         tls_lish = kubernetes.client.V1IngressTLS(
             hosts=["lish.internal"],
@@ -677,7 +678,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"whitelist-source-range": "10.0.0.0/24,172.10.0.1"})
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
         self.assertEqual(conf_or_rel._whitelist_source_range, "10.0.0.0/24,172.10.0.1")
-        result_dict = conf_or_rel._get_k8s_ingress().to_dict()
+        result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         self.assertEqual(
             result_dict["metadata"]["annotations"][
                 "nginx.ingress.kubernetes.io/whitelist-source-range"
@@ -695,7 +696,7 @@ class TestCharm(unittest.TestCase):
             }
         )
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
-        result_dict = conf_or_rel._get_k8s_ingress().to_dict()
+        result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
@@ -704,7 +705,7 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(result_dict["metadata"]["annotations"], expected)
 
         self.harness.update_config({"rewrite-enabled": False})
-        result_dict = conf_or_rel._get_k8s_ingress().to_dict()
+        result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -719,7 +720,7 @@ class TestCharm(unittest.TestCase):
             "nginx.ingress.kubernetes.io/rewrite-target": "/test-target",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
         }
-        result_dict = conf_or_rel._get_k8s_ingress().to_dict()
+        result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         self.assertEqual(result_dict["metadata"]["annotations"], expected)
 
     @patch("charm.NginxIngressCharm._on_config_changed")
@@ -834,6 +835,7 @@ class TestCharm(unittest.TestCase):
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
                 },
+                labels={CREATED_BY_LABEL: self.harness.charm.app.name},
             ),
             spec=kubernetes.client.V1IngressSpec(
                 rules=[
@@ -860,7 +862,7 @@ class TestCharm(unittest.TestCase):
             ),
         )
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
-        self.assertEqual(conf_or_rel._get_k8s_ingress(), expected)
+        self.assertEqual(conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name), expected)
         # Test additional hostnames
         self.harness.update_config({"additional-hostnames": "bar.internal,foo.external"})
         expected = kubernetes.client.V1Ingress(
@@ -873,6 +875,7 @@ class TestCharm(unittest.TestCase):
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
                 },
+                labels={CREATED_BY_LABEL: self.harness.charm.app.name},
             ),
             spec=kubernetes.client.V1IngressSpec(
                 rules=[
@@ -936,7 +939,7 @@ class TestCharm(unittest.TestCase):
                 ]
             ),
         )
-        self.assertEqual(conf_or_rel._get_k8s_ingress(), expected)
+        self.assertEqual(conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name), expected)
         self.harness.update_config({"additional-hostnames": ""})
         # Test multiple paths
         expected = kubernetes.client.V1Ingress(
@@ -949,6 +952,7 @@ class TestCharm(unittest.TestCase):
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
                 },
+                labels={CREATED_BY_LABEL: self.harness.charm.app.name},
             ),
             spec=kubernetes.client.V1IngressSpec(
                 rules=[
@@ -987,7 +991,7 @@ class TestCharm(unittest.TestCase):
             ),
         )
         self.harness.update_config({"path-routes": "/admin,/portal"})
-        self.assertEqual(conf_or_rel._get_k8s_ingress(), expected)
+        self.assertEqual(conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name), expected)
         self.harness.update_config({"path-routes": "/"})
         # Test with TLS.
         expected = kubernetes.client.V1Ingress(
@@ -999,6 +1003,7 @@ class TestCharm(unittest.TestCase):
                     "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                 },
+                labels={CREATED_BY_LABEL: self.harness.charm.app.name},
             ),
             spec=kubernetes.client.V1IngressSpec(
                 rules=[
@@ -1031,7 +1036,7 @@ class TestCharm(unittest.TestCase):
             ),
         )
         self.harness.update_config({"tls-secret-name": "gunicorn_tls"})
-        self.assertEqual(conf_or_rel._get_k8s_ingress(), expected)
+        self.assertEqual(conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name), expected)
         # Test ingress-class, max_body_size, retry_http_errors and
         # session-cookie-max-age config options.
         self.harness.update_config(
@@ -1062,6 +1067,7 @@ class TestCharm(unittest.TestCase):
                     "nginx.ingress.kubernetes.io/session-cookie-samesite": "Lax",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
                 },
+                labels={CREATED_BY_LABEL: self.harness.charm.app.name},
             ),
             spec=kubernetes.client.V1IngressSpec(
                 rules=[
@@ -1087,10 +1093,10 @@ class TestCharm(unittest.TestCase):
                 ]
             ),
         )
-        self.assertEqual(conf_or_rel._get_k8s_ingress(), expected)
+        self.assertEqual(conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name), expected)
         # Test limit-whitelist on its own makes no change.
         self.harness.update_config({"limit-whitelist": "10.0.0.0/16"})
-        self.assertEqual(conf_or_rel._get_k8s_ingress(), expected)
+        self.assertEqual(conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name), expected)
         # And if we set limit-rps we get both. Unset other options to minimize output.
         self.harness.update_config(
             {
@@ -1113,6 +1119,7 @@ class TestCharm(unittest.TestCase):
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
                 },
+                labels={CREATED_BY_LABEL: self.harness.charm.app.name},
             ),
             spec=kubernetes.client.V1IngressSpec(
                 rules=[
@@ -1138,7 +1145,7 @@ class TestCharm(unittest.TestCase):
                 ]
             ),
         )
-        self.assertEqual(conf_or_rel._get_k8s_ingress(), expected)
+        self.assertEqual(conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name), expected)
 
     def test_get_k8s_service(self):
         """Test getting our definition of a k8s service."""
@@ -1147,7 +1154,9 @@ class TestCharm(unittest.TestCase):
         expected = kubernetes.client.V1Service(
             api_version="v1",
             kind="Service",
-            metadata=kubernetes.client.V1ObjectMeta(name="gunicorn-service"),
+            metadata=kubernetes.client.V1ObjectMeta(
+                name="gunicorn-service", labels={CREATED_BY_LABEL: self.harness.charm.app.name}
+            ),
             spec=kubernetes.client.V1ServiceSpec(
                 selector={"app.kubernetes.io/name": "gunicorn"},
                 ports=[
@@ -1160,7 +1169,7 @@ class TestCharm(unittest.TestCase):
             ),
         )
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
-        self.assertEqual(conf_or_rel._get_k8s_service(), expected)
+        self.assertEqual(conf_or_rel._get_k8s_service(label=self.harness.charm.app.name), expected)
 
 
 INGRESS_CLASS_PUBLIC_DEFAULT = kubernetes.client.V1IngressClass(
@@ -1244,7 +1253,7 @@ class TestCharmLookUpAndSetIngressClass(unittest.TestCase):
         """If there are no ingress classes, there's nothing to choose from."""
         api = _make_mock_api_list_ingress_class(ZERO_INGRESS_CLASS_LIST)
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
-        body = conf_or_rel._get_k8s_ingress()
+        body = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name)
         self.harness.charm._look_up_and_set_ingress_class(api, body)
         self.assertIsNone(body.spec.ingress_class_name)
 
@@ -1252,7 +1261,7 @@ class TestCharmLookUpAndSetIngressClass(unittest.TestCase):
         """If there's one default ingress class, choose that."""
         api = _make_mock_api_list_ingress_class(ONE_INGRESS_CLASS_LIST)
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
-        body = conf_or_rel._get_k8s_ingress()
+        body = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name)
         self.harness.charm._look_up_and_set_ingress_class(api, body)
         self.assertEqual(body.spec.ingress_class_name, "public")
 
@@ -1260,7 +1269,7 @@ class TestCharmLookUpAndSetIngressClass(unittest.TestCase):
         """If there are two ingress classes, one default, choose that."""
         api = _make_mock_api_list_ingress_class(TWO_INGRESS_CLASSES_LIST)
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
-        body = conf_or_rel._get_k8s_ingress()
+        body = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name)
         self.harness.charm._look_up_and_set_ingress_class(api, body)
         self.assertEqual(body.spec.ingress_class_name, "public")
 
@@ -1268,7 +1277,7 @@ class TestCharmLookUpAndSetIngressClass(unittest.TestCase):
         """If there are two ingress classes, both default, choose neither."""
         api = _make_mock_api_list_ingress_class(TWO_INGRESS_CLASSES_LIST_TWO_DEFAULT)
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
-        body = conf_or_rel._get_k8s_ingress()
+        body = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name)
         self.harness.charm._look_up_and_set_ingress_class(api, body)
         self.assertIsNone(body.spec.ingress_class_name)
 
@@ -1409,7 +1418,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_create_service = mock_api.return_value.create_namespaced_service
         mock_create_service.assert_called_once_with(
             namespace=self.harness.charm._namespace,
-            body=conf_or_rels[0]._get_k8s_service(),
+            body=conf_or_rels[0]._get_k8s_service(label=self.harness.charm.app.name),
         )
 
         # Reset the create service mock, and add a second relation. Expect the first service to
@@ -1431,11 +1440,11 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_patch_service.assert_called_once_with(
             name=conf_or_rels[0]._k8s_service_name,
             namespace=self.harness.charm._namespace,
-            body=conf_or_rels[0]._get_k8s_service(),
+            body=conf_or_rels[0]._get_k8s_service(self.harness.charm.app.name),
         )
         mock_create_service.assert_called_once_with(
             namespace=self.harness.charm._namespace,
-            body=conf_or_rels[1]._get_k8s_service(),
+            body=conf_or_rels[1]._get_k8s_service(self.harness.charm.app.name),
         )
 
         # Remove the first relation and assert that only the first service is removed.
@@ -1496,12 +1505,13 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         conf_or_rels = self.harness.charm._all_config_or_relations
         mock_create_ingress = mock_api.return_value.create_namespaced_ingress
-
         # Since we only have one relation, the merged ingress rule should be the same as before
         # the merge.
+        expected_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
+        expected_body.metadata.labels = None
         mock_create_ingress.assert_called_once_with(
             namespace=self.harness.charm._namespace,
-            body=conf_or_rels[0]._get_k8s_ingress(),
+            body=expected_body,
         )
 
         # Reset the create ingress mock, and add a second relation.
@@ -1524,10 +1534,11 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_create_ingress.assert_not_called()
 
         conf_or_rels = self.harness.charm._all_config_or_relations
-        expected_body = conf_or_rels[0]._get_k8s_ingress()
-        second_body = conf_or_rels[1]._get_k8s_ingress()
+        expected_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
+        second_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
 
         expected_body.spec.rules[0].http.paths.extend(second_body.spec.rules[0].http.paths)
+        expected_body.metadata.labels = None
         mock_replace_ingress = mock_api.return_value.replace_namespaced_ingress
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[0]._ingress_name,
@@ -1547,6 +1558,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_delete_ingress.assert_not_called()
 
         conf_or_rels = self.harness.charm._all_config_or_relations
+        second_body.metadata.labels = None
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[0]._ingress_name,
             namespace=self.harness.charm._namespace,
@@ -1561,10 +1573,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         mock_create_ingress.assert_not_called()
         mock_replace_ingress.assert_not_called()
-        mock_delete_ingress.assert_called_once_with(
-            conf_or_rels[0]._ingress_name,
-            self.harness.charm._namespace,
-        )
+        mock_delete_ingress.assert_called_once()
 
     @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
     @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
@@ -1612,9 +1621,11 @@ class TestCharmMultipleRelations(unittest.TestCase):
         # the merge.
         conf_or_rels = self.harness.charm._all_config_or_relations
         mock_create_ingress = mock_api.return_value.create_namespaced_ingress
+        expected_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
+        expected_body.metadata.labels = None
         mock_create_ingress.assert_called_once_with(
             namespace=self.harness.charm._namespace,
-            body=conf_or_rels[0]._get_k8s_ingress(),
+            body=expected_body,
         )
 
         # Reset the create ingress mock, and add a second relation with a different
@@ -1635,15 +1646,19 @@ class TestCharmMultipleRelations(unittest.TestCase):
         # change, and that a new K8s Ingress Resource will be created for the new relation,
         # since it has a different service-hostname.
         conf_or_rels = self.harness.charm._all_config_or_relations
+        expected_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
+        expected_body.metadata.labels = None
         mock_create_ingress.assert_called_once_with(
             namespace=self.harness.charm._namespace,
-            body=conf_or_rels[1]._get_k8s_ingress(),
+            body=expected_body,
         )
         mock_replace_ingress = mock_api.return_value.replace_namespaced_ingress
+        expected_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
+        expected_body.metadata.labels = None
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[0]._ingress_name,
             namespace=self.harness.charm._namespace,
-            body=conf_or_rels[0]._get_k8s_ingress(),
+            body=expected_body,
         )
 
         # Remove the first relation and assert that only the first ingress is removed.
@@ -1661,10 +1676,12 @@ class TestCharmMultipleRelations(unittest.TestCase):
             self.harness.charm._namespace,
         )
         mock_create_ingress.assert_not_called()
+        expected_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
+        expected_body.metadata.labels = None
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[1]._ingress_name,
             namespace=self.harness.charm._namespace,
-            body=conf_or_rels[1]._get_k8s_ingress(),
+            body=expected_body,
         )
 
         # Remove the second relation.
@@ -1800,12 +1817,14 @@ class TestCharmMultipleRelations(unittest.TestCase):
         # It should create 2 different Ingress Resources, since we have an additional hostname.
         conf_or_rels = self.harness.charm._all_config_or_relations
         mock_create_ingress = mock_api.return_value.create_namespaced_ingress
-        first_body = conf_or_rels[0]._get_k8s_ingress()
+        first_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
         first_body.spec.rules = [first_body.spec.rules[0]]
-        second_body = conf_or_rels[0]._get_k8s_ingress()
+        first_body.metadata.labels = None
+        second_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
         second_body.metadata.name = "lish-in-ternal-ingress"
         second_body.spec.rules = [second_body.spec.rules[1]]
         second_body.spec.tls[0].hosts = ["lish.in.ternal"]
+        second_body.metadata.labels = None
         mock_create_ingress.assert_has_calls(
             [
                 mock.call(namespace=self.harness.charm._namespace, body=first_body),
@@ -1838,7 +1857,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
         conf_or_rels = self.harness.charm._all_config_or_relations
         mock_create_ingress.assert_not_called()
 
-        second_rel_body = conf_or_rels[1]._get_k8s_ingress()
+        second_rel_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
         second_body.spec.rules[0].http.paths.extend(second_rel_body.spec.rules[0].http.paths)
         calls = [
             mock.call(
@@ -1870,10 +1889,12 @@ class TestCharmMultipleRelations(unittest.TestCase):
             self.harness.charm._namespace,
         )
         mock_create_ingress.assert_not_called()
+        expected_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
+        expected_body.metadata.labels = None
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[1]._ingress_name,
             namespace=self.harness.charm._namespace,
-            body=conf_or_rels[1]._get_k8s_ingress(),
+            body=expected_body,
         )
 
     @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
@@ -2003,7 +2024,8 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         conf_or_rels = self.harness.charm._all_config_or_relations
         mock_define_service.assert_has_calls([mock.call(mock.ANY), mock.call(mock.ANY)])
-        second_body = conf_or_rels[1]._get_k8s_ingress()
-        expected_body = conf_or_rels[0]._get_k8s_ingress()
+        second_body = conf_or_rels[1]._get_k8s_ingress(None)
+        expected_body = conf_or_rels[0]._get_k8s_ingress(None)
         expected_body.spec.rules[0].http.paths.extend(second_body.spec.rules[0].http.paths)
+        expected_body.metadata.labels = None
         mock_define_ingress.assert_called_once_with(expected_body)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -619,7 +619,6 @@ class TestCharm(unittest.TestCase):
 
         mock_def_svc.assert_called_once()
         base_ingress = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name)
-        base_ingress.metadata.labels = None
 
         tls_lish = kubernetes.client.V1IngressTLS(
             hosts=["lish.internal"],
@@ -631,6 +630,7 @@ class TestCharm(unittest.TestCase):
             metadata=kubernetes.client.V1ObjectMeta(
                 name="lish-internal-ingress",
                 annotations=base_ingress.metadata.annotations,
+                labels={CREATED_BY_LABEL: self.harness.charm.app.name},
             ),
             spec=kubernetes.client.V1IngressSpec(
                 tls=[tls_lish],
@@ -1508,7 +1508,6 @@ class TestCharmMultipleRelations(unittest.TestCase):
         # Since we only have one relation, the merged ingress rule should be the same as before
         # the merge.
         expected_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
-        expected_body.metadata.labels = None
         mock_create_ingress.assert_called_once_with(
             namespace=self.harness.charm._namespace,
             body=expected_body,
@@ -1538,7 +1537,6 @@ class TestCharmMultipleRelations(unittest.TestCase):
         second_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
 
         expected_body.spec.rules[0].http.paths.extend(second_body.spec.rules[0].http.paths)
-        expected_body.metadata.labels = None
         mock_replace_ingress = mock_api.return_value.replace_namespaced_ingress
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[0]._ingress_name,
@@ -1558,7 +1556,6 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_delete_ingress.assert_not_called()
 
         conf_or_rels = self.harness.charm._all_config_or_relations
-        second_body.metadata.labels = None
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[0]._ingress_name,
             namespace=self.harness.charm._namespace,
@@ -1622,7 +1619,6 @@ class TestCharmMultipleRelations(unittest.TestCase):
         conf_or_rels = self.harness.charm._all_config_or_relations
         mock_create_ingress = mock_api.return_value.create_namespaced_ingress
         expected_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
-        expected_body.metadata.labels = None
         mock_create_ingress.assert_called_once_with(
             namespace=self.harness.charm._namespace,
             body=expected_body,
@@ -1647,14 +1643,12 @@ class TestCharmMultipleRelations(unittest.TestCase):
         # since it has a different service-hostname.
         conf_or_rels = self.harness.charm._all_config_or_relations
         expected_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
-        expected_body.metadata.labels = None
         mock_create_ingress.assert_called_once_with(
             namespace=self.harness.charm._namespace,
             body=expected_body,
         )
         mock_replace_ingress = mock_api.return_value.replace_namespaced_ingress
         expected_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
-        expected_body.metadata.labels = None
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[0]._ingress_name,
             namespace=self.harness.charm._namespace,
@@ -1677,7 +1671,6 @@ class TestCharmMultipleRelations(unittest.TestCase):
         )
         mock_create_ingress.assert_not_called()
         expected_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
-        expected_body.metadata.labels = None
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[1]._ingress_name,
             namespace=self.harness.charm._namespace,
@@ -1819,12 +1812,10 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_create_ingress = mock_api.return_value.create_namespaced_ingress
         first_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
         first_body.spec.rules = [first_body.spec.rules[0]]
-        first_body.metadata.labels = None
         second_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
         second_body.metadata.name = "lish-in-ternal-ingress"
         second_body.spec.rules = [second_body.spec.rules[1]]
         second_body.spec.tls[0].hosts = ["lish.in.ternal"]
-        second_body.metadata.labels = None
         mock_create_ingress.assert_has_calls(
             [
                 mock.call(namespace=self.harness.charm._namespace, body=first_body),
@@ -1890,7 +1881,6 @@ class TestCharmMultipleRelations(unittest.TestCase):
         )
         mock_create_ingress.assert_not_called()
         expected_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
-        expected_body.metadata.labels = None
         mock_replace_ingress.assert_called_once_with(
             name=conf_or_rels[1]._ingress_name,
             namespace=self.harness.charm._namespace,
@@ -2024,8 +2014,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         conf_or_rels = self.harness.charm._all_config_or_relations
         mock_define_service.assert_has_calls([mock.call(mock.ANY), mock.call(mock.ANY)])
-        second_body = conf_or_rels[1]._get_k8s_ingress(None)
-        expected_body = conf_or_rels[0]._get_k8s_ingress(None)
+        second_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
+        expected_body = conf_or_rels[0]._get_k8s_ingress(label=self.harness.charm.app.name)
         expected_body.spec.rules[0].http.paths.extend(second_body.spec.rules[0].http.paths)
-        expected_body.metadata.labels = None
         mock_define_ingress.assert_called_once_with(expected_body)

--- a/tox.ini
+++ b/tox.ini
@@ -102,7 +102,7 @@ commands =
 description = Run integration tests
 deps =
     pytest
-    juju
+    juju>=2,<3
     pytest-operator
     pytest-asyncio
     kubernetes


### PR DESCRIPTION
This PR focuses on the creation of a custom label for both services and ingresses, to not be dependant on the `app.juju.is/created-by=` label.