### PR TITLE
feat(ISD-482): Add proxy-read-timeout configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,6 +67,10 @@ options:
       Comma separated list of the routes under the hostname that you wish to map to the relation.
       Example: "/admin,/portal" will map example.test/admin and example.test/portal only.
     type: string
+  proxy-read-timeout:
+    default: 60
+    description: Defines a timeout in seconds for reading a response from the proxied server.
+    type: int
   retry-errors:
     default: ""
     description: |

--- a/src/charm.py
+++ b/src/charm.py
@@ -189,6 +189,12 @@ class _ConfigOrRelation:
         )
 
     @property
+    def _proxy_read_timeout(self) -> str:
+        """Return the proxy-read-timeout to use for k8s ingress."""
+        proxy_read_timeout = self._get_config_or_relation_data("proxy-read-timeout", 60)
+        return f"{proxy_read_timeout}"
+
+    @property
     def _rewrite_enabled(self) -> bool:
         """Return whether rewriting should be enabled from config or relation."""
         value = self._get_config_or_relation_data("rewrite-enabled", True)
@@ -337,6 +343,7 @@ class _ConfigOrRelation:
         spec = kubernetes.client.V1IngressSpec(rules=ingress_rules)
 
         annotations = {"nginx.ingress.kubernetes.io/proxy-body-size": self._max_body_size}
+        annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] = self._proxy_read_timeout
         if self._limit_rps:
             annotations["nginx.ingress.kubernetes.io/limit-rps"] = self._limit_rps
             if self._limit_whitelist:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -289,6 +289,7 @@ class TestCharm(unittest.TestCase):
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
         result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
+            "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -313,6 +314,7 @@ class TestCharm(unittest.TestCase):
                 ' "id:900130,phase:1,nolog,pass,t:none,setvar:tx.crs_exclusions_wordpress=1"\n'
                 "\nInclude /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf"
             ),
+            "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -340,6 +342,7 @@ class TestCharm(unittest.TestCase):
                 ' "id:900130,phase:1,nolog,pass,t:none,setvar:tx.crs_exclusions_wordpress=1"\n\n'
                 "\nInclude /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf"
             ),
+            "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -698,6 +701,7 @@ class TestCharm(unittest.TestCase):
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
         result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
+            "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -707,6 +711,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"rewrite-enabled": False})
         result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
+            "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
         }
@@ -716,6 +721,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config({"rewrite-enabled": True})
 
         expected = {
+            "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/test-target",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -831,6 +837,7 @@ class TestCharm(unittest.TestCase):
             metadata=kubernetes.client.V1ObjectMeta(
                 name=expected_ingress_name,
                 annotations={
+                    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -871,6 +878,7 @@ class TestCharm(unittest.TestCase):
             metadata=kubernetes.client.V1ObjectMeta(
                 name=expected_ingress_name,
                 annotations={
+                    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -948,6 +956,7 @@ class TestCharm(unittest.TestCase):
             metadata=kubernetes.client.V1ObjectMeta(
                 name=expected_ingress_name,
                 annotations={
+                    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -1000,6 +1009,7 @@ class TestCharm(unittest.TestCase):
             metadata=kubernetes.client.V1ObjectMeta(
                 name=expected_ingress_name,
                 annotations={
+                    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                 },
@@ -1056,6 +1066,7 @@ class TestCharm(unittest.TestCase):
                 annotations={
                     "nginx.ingress.kubernetes.io/affinity": "cookie",
                     "nginx.ingress.kubernetes.io/affinity-mode": "balanced",
+                    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "10m",
                     "nginx.ingress.kubernetes.io/proxy-next-upstream": (
                         "error timeout http_502 http_503"
@@ -1115,6 +1126,7 @@ class TestCharm(unittest.TestCase):
                 annotations={
                     "nginx.ingress.kubernetes.io/limit-rps": "5",
                     "nginx.ingress.kubernetes.io/limit-whitelist": "10.0.0.0/16",
+                    "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "0m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",


### PR DESCRIPTION
An application might have long-running operations that need more time to finish. The default proxy_read_timeout is 60s so if you need more than that and don't increase it, NGINX will give a 504 (Gateway Timeout) error.

This PR adds a new configuration to set proxy-read-timeout so it can be changed as required.

proxy-read-timeout: Defines a timeout in seconds for reading a response from the proxied server.

Reference [here](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-timeouts).