### PR TITLE
Fix the publish charm workflow

### DIFF
--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -18,3 +18,5 @@ jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
     secrets: inherit
+    with:
+      integration-test-modules: '["test_charm", "test_relation"]'


### PR DESCRIPTION
The integration test workflow from operator-workflows run multiple test modules in the same model. 

This behavior causes problems in the `test_delete_unused_ingresses` test case, since there will be some ingress resource residues from previous test runs.