### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/test_and_publish_charm.yaml
+++ b/.github/workflows/test_and_publish_charm.yaml
@@ -19,4 +19,4 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test_and_publish_charm.yaml@main
     secrets: inherit
     with:
-      integration-test-modules: '["test_charm", "test_relation"]'
+      integration-test-modules: '["test_relation"]'


### PR DESCRIPTION
Remove the module `test_charm` from the integrations tests. It doesn't exist anymore