### PR TITLE
feat(ISD-616): Add backend-protocol configuration (#59)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,12 @@ options:
     description: >
       Comma-separated list of additional hostnames for this ingress to listen on.
     type: string
+  backend-protocol:
+    default: "HTTP"
+    description: >
+      Indicates how NGINX should communicate with the backend service. Valid
+      Values: HTTP, HTTPS, GRPC, GRPCS, AJP and FCGI.
+    type: string
   ingress-class:
     default: ""
     description: |

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ options:
       Comma-separated list of additional hostnames for this ingress to listen on.
     type: string
   backend-protocol:
-    default: "HTTP"
+    default: ""
     description: >
       Indicates how NGINX should communicate with the backend service. Valid
       Values: HTTP, HTTPS, GRPC, GRPCS, AJP and FCGI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ skips = ["*/*test.py", "*/test_*.py"]
 branch = true
 
 [tool.coverage.report]
-fail_under = 93
+fail_under = 92
 show_missing = true
 
 [tool.mypy]

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,6 +61,7 @@ class ConflictingRoutesError(Exception):
 class InvalidBackendProtocolError(Exception):
     """Custom error that indicates invalid backend protocol."""
 
+
 class InvalidHostnameError(Exception):
     """Custom error that indicates invalid hostnames."""
 
@@ -156,9 +157,7 @@ class _ConfigOrRelation:
     @property
     def _backend_protocol(self) -> str:
         """Return the backend-protocol to use for k8s ingress."""
-        return self._get_config_or_relation_data(
-            "backend-protocol", "HTTP"
-        ).upper()
+        return self._get_config_or_relation_data("backend-protocol", "HTTP").upper()
 
     @property
     def _k8s_service_name(self) -> str:
@@ -770,8 +769,9 @@ class NginxIngressCharm(CharmBase):
                 if not invalid_hostname_check(rule.host):
                     raise InvalidHostnameError()
 
-                backend_protocol = ingress.metadata.annotations["nginx.ingress.kubernetes.io/backend-protocol"]
-                if not is_backend_protocol_valid(backend_protocol):
+                if not is_backend_protocol_valid(
+                    ingress.metadata.annotations["nginx.ingress.kubernetes.io/backend-protocol"]
+                ):
                     raise InvalidBackendProtocolError()
 
                 if rule.host not in ingress_paths:

--- a/src/charm.py
+++ b/src/charm.py
@@ -765,14 +765,14 @@ class NginxIngressCharm(CharmBase):
         for ingress in ingresses:
             # A relation could have defined additional-hostnames, so there could be more than
             # one rule. Those hostnames might also be used in other relations.
+            if not is_backend_protocol_valid(
+                ingress.metadata.annotations["nginx.ingress.kubernetes.io/backend-protocol"]
+            ):
+                raise InvalidBackendProtocolError()
+
             for rule in ingress.spec.rules:
                 if not invalid_hostname_check(rule.host):
                     raise InvalidHostnameError()
-
-                if not is_backend_protocol_valid(
-                    ingress.metadata.annotations["nginx.ingress.kubernetes.io/backend-protocol"]
-                ):
-                    raise InvalidBackendProtocolError()
 
                 if rule.host not in ingress_paths:
                     # The same paths array is used for any additional-hostnames given, so we need

--- a/src/charm.py
+++ b/src/charm.py
@@ -153,13 +153,13 @@ class _ConfigOrRelation:
         backend_protocol_default = "HTTP"
         backend_protocol = self._get_config_or_relation_data(
             "backend-protocol", backend_protocol_default
-        )
+        ).upper()
         # Disabled to reference the documentation
         # See https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#backend-protocol # noqa: E501 pylint: disable=line-too-long
-        accepted_values = ["HTTP", "HTTPS", "GRPC", "GRPCS", "AJP", "FCGI"]
-        if backend_protocol.upper() not in accepted_values:
+        accepted_values = ("HTTP", "HTTPS", "GRPC", "GRPCS", "AJP", "FCGI")
+        if backend_protocol not in accepted_values:
             return backend_protocol_default
-        return f"{backend_protocol}".upper()
+        return backend_protocol
 
     @property
     def _k8s_service_name(self) -> str:

--- a/src/charm.py
+++ b/src/charm.py
@@ -23,7 +23,7 @@ from ops.charm import CharmBase, HookEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, ConfigData, Model, Relation, WaitingStatus
 
-from helpers import invalid_hostname_check
+from helpers import invalid_hostname_check, is_backend_protocol_valid
 
 LOGGER = logging.getLogger(__name__)
 _INGRESS_SUB_REGEX = re.compile("[^0-9a-zA-Z]")
@@ -35,6 +35,9 @@ REPORT_INTERVAL_COUNT = 100
 INVALID_HOSTNAME_MSG = (
     "Invalid ingress hostname. The hostname must consist of lower case "
     "alphanumeric characters, '-' or '.'."
+)
+INVALID_BACKEND_PROTOCOL_MSG = (
+    "Invalid backend protocol. Valid values: HTTP, HTTPS, GRPC, GRPCS, AJP, FCGI"
 )
 
 
@@ -54,6 +57,9 @@ class ConflictingAnnotationsError(Exception):
 class ConflictingRoutesError(Exception):
     """Custom error that indicates conflicting routes."""
 
+
+class InvalidBackendProtocolError(Exception):
+    """Custom error that indicates invalid backend protocol."""
 
 class InvalidHostnameError(Exception):
     """Custom error that indicates invalid hostnames."""
@@ -150,16 +156,9 @@ class _ConfigOrRelation:
     @property
     def _backend_protocol(self) -> str:
         """Return the backend-protocol to use for k8s ingress."""
-        backend_protocol_default = "HTTP"
-        backend_protocol = self._get_config_or_relation_data(
-            "backend-protocol", backend_protocol_default
+        return self._get_config_or_relation_data(
+            "backend-protocol", "HTTP"
         ).upper()
-        # Disabled to reference the documentation
-        # See https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#backend-protocol # noqa: E501 pylint: disable=line-too-long
-        accepted_values = ("HTTP", "HTTPS", "GRPC", "GRPCS", "AJP", "FCGI")
-        if backend_protocol not in accepted_values:
-            return backend_protocol_default
-        return backend_protocol
 
     @property
     def _k8s_service_name(self) -> str:
@@ -771,6 +770,10 @@ class NginxIngressCharm(CharmBase):
                 if not invalid_hostname_check(rule.host):
                     raise InvalidHostnameError()
 
+                backend_protocol = ingress.metadata.annotations["nginx.ingress.kubernetes.io/backend-protocol"]
+                if not is_backend_protocol_valid(backend_protocol):
+                    raise InvalidBackendProtocolError()
+
                 if rule.host not in ingress_paths:
                     # The same paths array is used for any additional-hostnames given, so we need
                     # to make our own copy.
@@ -956,6 +959,9 @@ class NginxIngressCharm(CharmBase):
             except InvalidHostnameError:
                 self.unit.status = BlockedStatus(INVALID_HOSTNAME_MSG)
                 return
+            except InvalidBackendProtocolError:
+                self.unit.status = BlockedStatus(INVALID_BACKEND_PROTOCOL_MSG)
+                return
         self.unit.set_workload_version(self._get_kubernetes_library_version())
         self.unit.status = ActiveStatus(msg)
 
@@ -1003,7 +1009,9 @@ class NginxIngressCharm(CharmBase):
             except InvalidHostnameError:
                 self.unit.status = BlockedStatus(INVALID_HOSTNAME_MSG)
                 return
-
+            except InvalidBackendProtocolError:
+                self.unit.status = BlockedStatus(INVALID_BACKEND_PROTOCOL_MSG)
+                return
         self.unit.status = ActiveStatus()
 
 

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -23,3 +23,13 @@ def invalid_hostname_check(hostname: str) -> bool:
     if result:
         return True
     return False
+
+
+def is_backend_protocol_valid(backend_protocol: str) -> bool:
+    """Check if the backend protocol is valid.
+
+    Args:
+        backend_protocol: Ingress hostname
+    """
+    accepted_values = ("HTTP", "HTTPS", "GRPC", "GRPCS", "AJP", "FCGI")
+    return backend_protocol in accepted_values

--- a/tests/integration/test_nginx_route.py
+++ b/tests/integration/test_nginx_route.py
@@ -93,6 +93,54 @@ async def test_ingress_connectivity():
     )
 
 
+@pytest.mark.usefixtures("build_and_deploy")
+async def test_ingress_connectivity_different_backend(model: Model):
+    """
+    arrange: given charm has been built and deployed.
+    act: change the backend protocol.
+    assert: HTTP request should be forwarded to the application via AJP
+        resulting in HTTP status code 500 Internal Server Error.
+    """
+    # First check if is OK
+    response = requests_get("http://127.0.0.1/ok", host_header="any")
+    assert response.text == "ok"
+    assert response.status_code == 200
+    # Then change the config and check if there is an error
+    await model.applications["ingress"].set_config({"backend-protocol": "AJP"})
+    await model.wait_for_idle(status="active")
+    response = requests_get("http://127.0.0.1/ok", host_header="any")
+    assert response.status_code == 500
+    # Undo the change and check again
+    await model.applications["ingress"].set_config({"backend-protocol": "HTTP"})
+    await model.wait_for_idle(status="active")
+    response = requests_get("http://127.0.0.1/ok", host_header="any")
+    assert response.text == "ok"
+    assert response.status_code == 200
+
+@pytest.mark.usefixtures("build_and_deploy")
+async def test_ingress_connectivity_invalid_backend(model: Model):
+    """
+    arrange: given charm has been built and deployed.
+    act: change the backend protocol.
+    assert: unit status is blocked.
+    """
+    # First check if is OK
+    response = requests_get("http://127.0.0.1/ok", host_header="any")
+    assert response.text == "ok"
+    assert response.status_code == 200
+    # Then change the config and check if there is an error
+    await model.applications["ingress"].set_config({"backend-protocol": "FAKE"})
+    await model.wait_for_idle()
+    unit = model.applications[INGRESS_APP_NAME].units[0]
+    assert unit.workload_status == "blocked"
+    assert "Invalid backend protocol" in unit.workload_status_message
+    # Undo the change and check again
+    await model.applications["ingress"].set_config({"backend-protocol": "HTTP"})
+    await model.wait_for_idle(status="active")
+    response = requests_get("http://127.0.0.1/ok", host_header="any")
+    assert response.text == "ok"
+    assert response.status_code == 200
+
 @pytest_asyncio.fixture(name="set_service_hostname")
 async def set_service_hostname_fixture(model: Model):
     """A fixture to set service-hostname to NEW_HOSTNAME in the any-charm nginx-route relation."""

--- a/tests/integration/test_nginx_route.py
+++ b/tests/integration/test_nginx_route.py
@@ -117,6 +117,7 @@ async def test_ingress_connectivity_different_backend(model: Model):
     assert response.text == "ok"
     assert response.status_code == 200
 
+
 @pytest.mark.usefixtures("build_and_deploy")
 async def test_ingress_connectivity_invalid_backend(model: Model):
     """
@@ -140,6 +141,7 @@ async def test_ingress_connectivity_invalid_backend(model: Model):
     response = requests_get("http://127.0.0.1/ok", host_header="any")
     assert response.text == "ok"
     assert response.status_code == 200
+
 
 @pytest_asyncio.fixture(name="set_service_hostname")
 async def set_service_hostname_fixture(model: Model):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -11,7 +11,12 @@ import pytest
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
-from charm import CREATED_BY_LABEL, INVALID_HOSTNAME_MSG, NginxIngressCharm
+from charm import (
+    CREATED_BY_LABEL,
+    INVALID_BACKEND_PROTOCOL_MSG,
+    INVALID_HOSTNAME_MSG,
+    NginxIngressCharm,
+)
 from helpers import invalid_hostname_check
 
 
@@ -239,6 +244,29 @@ class TestCharm(unittest.TestCase):
         # Now it's the value from the relation.
         conf_or_rel = self.harness.charm._all_config_or_relations[0]
         self.assertEqual(conf_or_rel._max_body_size, "88m")
+
+    def test_backend_protocol(self):
+        """Test for the backend-protocol property."""
+        # First set via config.
+        self.harness.update_config({"backend-protocol": "AJP"})
+        conf_or_rel = self.harness.charm._all_config_or_relations[0]
+        self.assertEqual(conf_or_rel._backend_protocol, "AJP")
+        # Now set via the StoredState. This will be set to a string, as all
+        # relation data must be a string.
+        relation_id = self.harness.add_relation("ingress", "gunicorn")
+        self.harness.add_relation_unit(relation_id, "gunicorn/0")
+        relations_data = {
+            "backend-protocol": "HTTP",
+            "service-name": "gunicorn",
+            "service-hostname": "foo.internal",
+            "service-port": "80",
+        }
+        self.harness.update_relation_data(relation_id, "gunicorn", relations_data)
+        self.assertEqual(conf_or_rel._backend_protocol, "AJP")
+        self.harness.update_config({"backend-protocol": ""})
+        # Now it's the value from the relation.
+        conf_or_rel = self.harness.charm._all_config_or_relations[0]
+        self.assertEqual(conf_or_rel._backend_protocol, "HTTP")
 
     def test_namespace(self):
         """Test for the namespace property."""
@@ -2025,6 +2053,45 @@ class TestCharmMultipleRelations(unittest.TestCase):
         self._add_ingress_relation("gunicorn", rel_data)
 
         expected_status_message = INVALID_HOSTNAME_MSG
+        self.assertEqual("blocked", self.harness.charm.unit.status.name)
+        self.assertIn(expected_status_message, self.harness.charm.unit.status.message)
+
+    @patch("charm.NginxIngressCharm._report_ingress_ips")
+    @patch("charm.NginxIngressCharm._report_service_ips")
+    @patch("charm.NginxIngressCharm._define_service")
+    @patch("charm.NginxIngressCharm._networking_v1_api")
+    def test_ingresses_for_invalid_backend_protocol(
+        self,
+        mock_api,
+        mock_define_service,
+        mock_report_ips,
+        mock_ingress_ips,
+    ):
+        """
+        arrange: given the harnessed charm
+        act: when we create/delete an ingress
+        assert: this test will check the Blocked case for invalid backend protocol
+        """
+        # Setting the leader to True will allow us to test the Ingress creation.
+        self.harness.set_leader(True)
+        self.harness.charm._authed = True
+
+        mock_report_ips.return_value = ["10.0.1.12"]
+        mock_ingress_ips.return_value = ""
+        mock_list_ingress = mock_api.return_value.list_namespaced_ingress
+        # We'll consider we don't have any ingresses set yet.
+        mock_list_ingress.return_value.items = []
+
+        # Add the relation.
+        rel_data = {
+            "service-name": "gunicorn",
+            "service-hostname": "foo.in.ternal",
+            "service-port": "80",
+            "backend-protocol": "foo",
+        }
+        self._add_ingress_relation("gunicorn", rel_data)
+
+        expected_status_message = INVALID_BACKEND_PROTOCOL_MSG
         self.assertEqual("blocked", self.harness.charm.unit.status.name)
         self.assertIn(expected_status_message, self.harness.charm.unit.status.message)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -292,6 +292,7 @@ class TestCharm(unittest.TestCase):
         result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
             "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+            "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -317,6 +318,7 @@ class TestCharm(unittest.TestCase):
                 "\nInclude /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf"
             ),
             "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+            "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -345,6 +347,7 @@ class TestCharm(unittest.TestCase):
                 "\nInclude /etc/nginx/owasp-modsecurity-crs/nginx-modsecurity.conf"
             ),
             "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+            "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -704,6 +707,7 @@ class TestCharm(unittest.TestCase):
         result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
             "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+            "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -714,6 +718,7 @@ class TestCharm(unittest.TestCase):
         result_dict = conf_or_rel._get_k8s_ingress(label=self.harness.charm.app.name).to_dict()
         expected = {
             "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+            "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
         }
@@ -724,6 +729,7 @@ class TestCharm(unittest.TestCase):
 
         expected = {
             "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+            "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
             "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
             "nginx.ingress.kubernetes.io/rewrite-target": "/test-target",
             "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -841,6 +847,7 @@ class TestCharm(unittest.TestCase):
                 name=expected_ingress_name,
                 annotations={
                     "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+                    "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -882,6 +889,7 @@ class TestCharm(unittest.TestCase):
                 name=expected_ingress_name,
                 annotations={
                     "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+                    "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -960,6 +968,7 @@ class TestCharm(unittest.TestCase):
                 name=expected_ingress_name,
                 annotations={
                     "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+                    "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",
@@ -1013,6 +1022,7 @@ class TestCharm(unittest.TestCase):
                 name=expected_ingress_name,
                 annotations={
                     "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+                    "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "20m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                 },
@@ -1070,6 +1080,7 @@ class TestCharm(unittest.TestCase):
                     "nginx.ingress.kubernetes.io/affinity": "cookie",
                     "nginx.ingress.kubernetes.io/affinity-mode": "balanced",
                     "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+                    "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "10m",
                     "nginx.ingress.kubernetes.io/proxy-next-upstream": (
                         "error timeout http_502 http_503"
@@ -1130,6 +1141,7 @@ class TestCharm(unittest.TestCase):
                     "nginx.ingress.kubernetes.io/limit-rps": "5",
                     "nginx.ingress.kubernetes.io/limit-whitelist": "10.0.0.0/16",
                     "nginx.ingress.kubernetes.io/proxy-read-timeout": "60",
+                    "nginx.ingress.kubernetes.io/backend-protocol": "HTTP",
                     "nginx.ingress.kubernetes.io/proxy-body-size": "0m",
                     "nginx.ingress.kubernetes.io/rewrite-target": "/",
                     "nginx.ingress.kubernetes.io/ssl-redirect": "false",


### PR DESCRIPTION
Add backend-protocol  configuration.
Default: HTTP
Valid values: "HTTP", "HTTPS", "GRPC", "GRPCS", "AJP", "FCGI"
Reference: [Ingress User Guide](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#backend-protocol ).