### PR TITLE
Update documentation for nginx-route library to avoid needing config for external hostname

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Fixtures for Nginx-ingress-integrator charm tests."""
+
+
+def pytest_addoption(parser):
+    """Parse additional pytest options.
+
+    Args:
+        parser: Pytest parser.
+    """
+    parser.addoption("--charm-file", action="store")


### PR DESCRIPTION
Update the documentation of the nginx-route library to avoid the recommendation that the local charm has an `external-hostname` (or similar) config option that it passes to the nginx-ingress-integrator charm over the relation. Instead, default to `self.app.name` and let this be overridden using the `service-hostname` option of the nginx-ingress-integrator charm.

This means the local charm can have one less config option, but still uses the best practice of defaulting to the deployed application name.