### PR TITLE
Update documentation for ingress library to avoid needing config for external hostname

### DIFF
--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -35,16 +35,13 @@ As an example, add the following to `src/charm.py`:
 ```
 from charms.nginx_ingress_integrator.v0.ingress import IngressRequires
 
-# In your charm's `__init__` method.
+# In your charm's `__init__` method (assuming your app is listening on port 8080).
 self.ingress = IngressRequires(self, {
-        "service-hostname": self.config["external_hostname"],
+        "service-hostname": self.app.name,
         "service-name": self.app.name,
-        "service-port": 80,
+        "service-port": 8080,
     }
 )
-
-# In your charm's `config-changed` handler.
-self.ingress.update_config({"service-hostname": self.config["external_hostname"]})
 ```
 And then add the following to `metadata.yaml`:
 ```
@@ -55,6 +52,22 @@ requires:
 You _must_ register the IngressRequires class as part of the `__init__` method
 rather than, for instance, a config-changed event handler, for the relation
 changed event to be properly handled.
+
+In the example above we're setting `service-hostname` (which translates to the
+external hostname for the application when related to nginx-ingress-integrator)
+to `self.app.name` here. This ensures by default the charm will be available on
+the name of the deployed juju application, but can be overridden in a
+production deployment by setting `service-hostname` on the
+nginx-ingress-integrator charm. For example:
+```bash
+juju deploy nginx-ingress-integrator
+juju deploy my-charm
+juju relate nginx-ingress-integrator my-charm:ingress
+# The service is now reachable on the ingress IP(s) of your k8s cluster at
+# 'http://my-charm'.
+juju config nginx-ingress-integrator service-hostname='my-charm.example.com'
+# The service is now reachable on the ingress IP(s) of your k8s cluster at
+# 'http://my-charm.example.com'.
 """
 
 import copy
@@ -76,7 +89,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 16
+LIBPATCH = 17
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Similarly to https://github.com/canonical/nginx-ingress-integrator-operator/pull/83 update the documentation of the ingress library to avoid the recommendation that the local charm has an external-hostname (or similar) config option that it passes to the nginx-ingress-integrator charm over the relation. Instead, default to self.app.name and let this be overridden using the service-hostname option of the nginx-ingress-integrator charm.

This means the local charm can have one less config option, but still uses the best practice of defaulting to the deployed application name.

Note that this library/relation doesn't yet implement the "ingress" relation as defined in the charm-relation-interfaces project. This update doesn't change that, but that will be addressed in future changes, at which point this library will need updating as well.