### PR TITLE
Handle the start event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -520,7 +520,11 @@ class NginxIngressCharm(CharmBase):
             self.unit.status = status.from_name(status.name, warning)
 
     def _on_start(self, event: Any) -> None:
-        """Handle the start event."""
+        """Handle the start event.
+
+        Args:
+            event: not used.
+        """
         # We need to set ActiveStatus here because this is a workload-less
         # charm, so there's no pebble-ready event to react to. This means this
         # is the only event (outside of update-status) that is fired if a pod is

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,7 @@ from charms.nginx_ingress_integrator.v0.ingress import (
     IngressProvides,
 )
 from charms.nginx_ingress_integrator.v0.nginx_route import provide_nginx_route
-from ops.charm import CharmBase, HookEvent
+from ops.charm import CharmBase, HookEvent, StartEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, ConfigData, Model, Relation, WaitingStatus
 
@@ -519,7 +519,7 @@ class NginxIngressCharm(CharmBase):
             )
             self.unit.status = status.from_name(status.name, warning)
 
-    def _on_start(self, _: Any) -> None:
+    def _on_start(self, _: StartEvent) -> None:
         """Handle the start event."""
         # We need to set ActiveStatus here because this is a workload-less
         # charm, so there's no pebble-ready event to react to. This means this

--- a/src/charm.py
+++ b/src/charm.py
@@ -519,12 +519,8 @@ class NginxIngressCharm(CharmBase):
             )
             self.unit.status = status.from_name(status.name, warning)
 
-    def _on_start(self, event: Any) -> None:
-        """Handle the start event.
-
-        Args:
-            event: not used.
-        """
+    def _on_start(self, _: Any) -> None:
+        """Handle the start event."""
         # We need to set ActiveStatus here because this is a workload-less
         # charm, so there's no pebble-ready event to react to. This means this
         # is the only event (outside of update-status) that is fired if a pod is

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import kubernetes
 import kubernetes.client
 import pytest
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
 from charm import (
@@ -28,6 +28,16 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(NginxIngressCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+
+    def test_start(self):
+        """
+        arrange: when the charm is first initialised
+        act: we then run the start hook
+        assert: we change from Maintenance to Active status
+        """
+        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus())
+        self.harness.charm.on.start.emit()
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
 
     @patch("charm.NginxIngressCharm._delete_unused_ingresses")
     @patch("charm.NginxIngressCharm._delete_unused_services")


### PR DESCRIPTION
We need to set `ActiveStatus` in the `start` event because this is a workload-less charm, so there's no `pebble-ready` event to react to. This means this is the only event (outside of `update-status`) that is fired if a pod is restarted by the k8s cluster. If we don't do anything here the charm would remain in maintenance status.