### PR TITLE
Support zero downtime upgrade from legacy ingress relation to nginx-route relation

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,4 +8,4 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      modules: '["test_relation", "test_nginx_route"]'
+      modules: '["test_relation", "test_nginx_route", "test_zero_downtime"]'

--- a/src/charm.py
+++ b/src/charm.py
@@ -573,6 +573,10 @@ class NginxIngressCharm(CharmBase):
         dedup_ingress_relations = []
         for relation in ingress_relations:
             if key(relation) in nginx_route_relation_keys:
+                LOGGER.warning(
+                    "legacy ingress relation from app %s is shadowed by nginx-route relation",
+                    relation.app,
+                )
                 continue
             dedup_ingress_relations.append(relation)
         return nginx_route_relations + dedup_ingress_relations

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,9 +9,11 @@
 import logging
 import re
 import time
+import typing
 from typing import Any, Dict, Generator, List, Optional, Union
 
 import kubernetes.client
+import ops
 from charms.nginx_ingress_integrator.v0.ingress import (
     RELATION_INTERFACES_MAPPINGS,
     REQUIRED_INGRESS_RELATION_FIELDS,
@@ -528,6 +530,53 @@ class NginxIngressCharm(CharmBase):
         # would remain in maintenance status.
         self.unit.status = ActiveStatus()
 
+    def _deduped_relations(self) -> List[ops.Relation]:
+        """Return a relation list with duplicates removed.
+
+        Relations are considered duplicated if they meet the following criteria:
+        1. Two are connected via the legacy ingress and the nginx-route relation endpoint
+        2. Two share the same 4-tuple (service-hostname, service-name, service-model, service-port)
+        3. Both relations have the same remote application.
+
+        In the case of duplicates, the relation connected via legacy ingress is removed.
+
+        Returns:
+            A relation list with duplicates removed.
+        """
+
+        def key(rel: Relation) -> typing.Tuple[str, ...]:
+            """Generate a key from the given relation to detect duplicates.
+
+            Args:
+                rel: the given relation object.
+
+            Returns: The key as a tuple of strings.
+
+            Raises:
+                RuntimeError: if the remote application is unknown.
+            """
+            app = rel.app
+            if not app:
+                raise RuntimeError(f"can't retrieve remote application from relation {rel}")
+            data = rel.data[app]
+            return (
+                data.get("service-hostname"),
+                data.get("service-name"),
+                data.get("service-model"),
+                data.get("service-port"),
+                app.name,
+            )
+
+        nginx_route_relations = self.model.relations["nginx-route"]
+        ingress_relations = self.model.relations["ingress"]
+        nginx_route_relation_keys = set(key(r) for r in nginx_route_relations)
+        dedup_ingress_relations = []
+        for relation in ingress_relations:
+            if key(relation) in nginx_route_relation_keys:
+                continue
+            dedup_ingress_relations.append(relation)
+        return nginx_route_relations + dedup_ingress_relations
+
     @property
     def _all_config_or_relations(self) -> Any:
         """Get all configuration and relation data.
@@ -535,7 +584,7 @@ class NginxIngressCharm(CharmBase):
         Returns:
             All configuration and relation data.
         """
-        all_relations = self.model.relations["ingress"] + self.model.relations["nginx-route"]
+        all_relations = self._deduped_relations()
         if not all_relations:
             all_relations = [None]  # type: ignore[list-item]
         multiple_rels = self._multiple_relations
@@ -551,7 +600,7 @@ class NginxIngressCharm(CharmBase):
         Returns:
             if we're related to multiple applications or not.
         """
-        return len(self.model.relations["ingress"]) + len(self.model.relations["nginx-route"]) > 1
+        return len(self._deduped_relations()) > 1
 
     @property
     def _namespace(self) -> Any:
@@ -837,20 +886,6 @@ class NginxIngressCharm(CharmBase):
         ]
 
         ingresses = self._process_ingresses(ingresses)
-
-        # Check if we need to remove any Ingresses from the excluded relation. If it has hostnames
-        # that are not used by any other relation, we need to remove them.
-        if excluded_relation:
-            conf_or_rel = _ConfigOrRelation(
-                self.model, self.config, excluded_relation, self._multiple_relations
-            )
-            excluded_ingress = conf_or_rel._get_k8s_ingress(self.app.name)
-
-            # The Kubernetes Ingress Resources we're creating only has 1 rule per hostname.
-            used_hostnames = [ingress.spec.rules[0].host for ingress in ingresses]
-            for rule in excluded_ingress.spec.rules:
-                if rule.host not in used_hostnames:
-                    self._remove_ingress(self._ingress_name(rule.host))
 
         for ingress in ingresses:
             self._define_ingress(ingress)
@@ -1142,7 +1177,7 @@ class NginxIngressCharm(CharmBase):
                 # on the existing relations, and remove any resources that are no longer needed
                 # (they were needed by the event relation).
                 self._define_ingresses(excluded_relation=event.relation)
-                self._remove_service(conf_or_rel)
+                self._delete_unused_resources()
             except kubernetes.client.exceptions.ApiException as exception:
                 if exception.status == 403:
                     LOGGER.error(

--- a/tests/integration/test_zero_downtime.py
+++ b/tests/integration/test_zero_downtime.py
@@ -1,0 +1,117 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Test the zero downtime upgrade process from legacy ingress relation to nginx-route."""
+
+import json
+from pathlib import Path
+
+import kubernetes
+from juju.application import Application
+from juju.model import Model
+from pytest_operator.plugin import OpsTest
+
+ANY_CHARM_COMMON = """
+from any_charm_base import AnyCharmBase
+from ingress import IngressRequires
+from nginx_route import require_nginx_route
+
+
+class AnyCharm(AnyCharmBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+"""
+
+ANY_CHARM_INGRESS = (
+    ANY_CHARM_COMMON
+    + """
+        self.ingress = IngressRequires(
+            self,
+            {
+                "service-hostname": self.app.name,
+                "service-name": self.app.name,
+                "service-port": 8080,
+            },
+        )
+"""
+)
+
+ANY_CHARM_NGINX_ROUTE = (
+    ANY_CHARM_COMMON
+    + """
+        require_nginx_route(
+            charm=self,
+            service_hostname=self.app.name,
+            service_name=self.app.name,
+            service_port=8080,
+        )
+"""
+)
+
+ANY_CHARM_DUAL = (
+    ANY_CHARM_INGRESS
+    + """
+        require_nginx_route(
+            charm=self,
+            service_hostname=self.app.name,
+            service_name=self.app.name,
+            service_port=8080,
+        )
+"""
+)
+
+
+async def test_zero_downtime(
+    ops_test: OpsTest, model: Model, build_and_deploy_ingress, wait_for_ingress
+):
+    """Test the zero downtime upgrade process from legacy ingress relation to nginx-route."""
+    ingress: Application = await build_and_deploy_ingress()
+    lib_path = Path("lib/charms/nginx_ingress_integrator/v0")
+    src_overwrite = {
+        "any_charm.py": ANY_CHARM_INGRESS,
+        "ingress.py": (lib_path / "ingress.py").read_text(),
+        "nginx_route.py": (lib_path / "nginx_route.py").read_text(),
+    }
+    any_charm: Application = await model.deploy(
+        "any-charm", channel="beta", config={"src-overwrite": json.dumps(src_overwrite)}
+    )
+    await model.relate("any-charm:ingress", f"{ingress.name}:ingress")
+    await model.wait_for_idle()
+    ingress_name = "any-charm-ingress"
+    service_name = "any-charm-service"
+    await wait_for_ingress(ingress_name)
+
+    kubernetes.config.load_kube_config()
+    networking_api = kubernetes.client.NetworkingV1Api()
+    core_api = kubernetes.client.CoreV1Api()
+    ingress_uid = networking_api.read_namespaced_ingress(
+        name=ingress_name, namespace=model.name
+    ).metadata.uid
+    service_uid = core_api.read_namespaced_service(
+        name=service_name, namespace=model.name
+    ).metadata.uid
+
+    src_overwrite["any_charm.py"] = ANY_CHARM_DUAL
+    await any_charm.set_config({"src-overwrite": src_overwrite})
+    await model.wait_for_idle()
+    await model.relate("any-charm:nginx-route", f"{ingress.name}:nginx-route")
+    await model.wait_for_idle()
+
+    assert len(networking_api.list_namespaced_ingress(namespace=model.name).items) == 1
+
+    await ops_test.juju("remove-relation", "any-charm:ingress", f"{ingress.name}:ingress")
+    await model.wait_for_idle()
+    src_overwrite["any_charm.py"] = ANY_CHARM_NGINX_ROUTE
+    await any_charm.set_config({"src-overwrite": src_overwrite})
+    await model.wait_for_idle()
+
+    assert (
+        ingress_uid
+        == networking_api.read_namespaced_ingress(
+            name=ingress_name, namespace=model.name
+        ).metadata.uid
+    )
+    assert (
+        service_uid
+        == core_api.read_namespaced_service(name=service_name, namespace=model.name).metadata.uid
+    )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -17,6 +17,8 @@ from charm import (
     INVALID_HOSTNAME_MSG,
     ConflictingAnnotationsError,
     ConflictingRoutesError,
+    InvalidBackendProtocolError,
+    InvalidHostnameError,
     NginxIngressCharm,
 )
 from helpers import invalid_hostname_check
@@ -869,6 +871,20 @@ class TestCharm(unittest.TestCase):
                 "Duplicate route found; cannot add ingress. Run juju debug-log for details."
             ),
         ),
+
+    def test_on_ingress_relation_invalid_hostname(self):
+        """Test invalid hostname error on ingress relation broken"""
+        self._run_on_ingress_relation_broken_exception(
+            InvalidHostnameError(),
+            BlockedStatus(INVALID_HOSTNAME_MSG),
+        )
+
+    def test_on_ingress_relation_invalid_backend_protocol(self):
+        """Test invalid backend protocol on ingress relation broken"""
+        self._run_on_ingress_relation_broken_exception(
+            InvalidBackendProtocolError(),
+            BlockedStatus(INVALID_BACKEND_PROTOCOL_MSG),
+        )
 
     @patch("charm.NginxIngressCharm._networking_v1_api")
     @patch("charm.NginxIngressCharm._core_v1_api")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,6 +15,8 @@ from charm import (
     CREATED_BY_LABEL,
     INVALID_BACKEND_PROTOCOL_MSG,
     INVALID_HOSTNAME_MSG,
+    ConflictingAnnotationsError,
+    ConflictingRoutesError,
     NginxIngressCharm,
 )
 from helpers import invalid_hostname_check
@@ -820,24 +822,53 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(conf_or_rel._service_name, "gunicorn")
         self.assertEqual(conf_or_rel._service_port, 80)
 
-    @patch("charm.NginxIngressCharm._remove_ingress")
-    @patch("charm.NginxIngressCharm._remove_service")
-    def test_on_ingress_relation_broken_unauthorized(self, _remove_service, _remove_ingress):
-        """Test the Unauthorized case on relation-broken."""
-        # Call the test test_on_ingress_relation_changed first
-        # to make sure the relation is created and therefore can be removed.
-        self.test_on_ingress_relation_changed()
-        _remove_service.side_effect = kubernetes.client.exceptions.ApiException(status=403)
+    def _run_on_ingress_relation_broken_exception(self, exception, expected_status):
+        """Test exceptions on relation-broken.
 
-        self.harness.charm._authed = True
-        relation = self.harness.charm.model.get_relation("ingress")
-        self.harness.remove_relation(relation.id)  # type: ignore[union-attr]
+        Args:
+            exception: exception to be raised in the relation broken handler.
+            expected_status: expected unit status.
+        """
+        with patch(
+            "charm.NginxIngressCharm._define_ingresses",
+            side_effect=exception,
+        ), patch("charm.NginxIngressCharm._delete_unused_services"):
+            # Call the test test_on_ingress_relation_changed first
+            # to make sure the relation is created and therefore can be removed.
+            self.test_on_ingress_relation_changed()
+            self.harness.charm._authed = True
+            relation = self.harness.charm.model.get_relation("ingress")
+            self.harness.remove_relation(relation.id)  # type: ignore[union-attr]
+            self.assertEqual(self.harness.charm.unit.status, expected_status)
 
-        expected_status = BlockedStatus(
-            "Insufficient permissions, try: `juju trust %s --scope=cluster`"
-            % self.harness.charm.app.name
+    def test_on_ingress_relation_broken_unauthorized(self):
+        """Test unauthorized error on ingress relation broken"""
+        self._run_on_ingress_relation_broken_exception(
+            kubernetes.client.exceptions.ApiException(status=403),
+            BlockedStatus(
+                "Insufficient permissions, "
+                "try: `juju trust nginx-ingress-integrator --scope=cluster`"
+            ),
         )
-        self.assertEqual(self.harness.charm.unit.status, expected_status)
+
+    def test_on_ingress_relation_broken_conflict_annotation(self):
+        """Test conflict annotation error on ingress relation broken"""
+        self._run_on_ingress_relation_broken_exception(
+            ConflictingAnnotationsError(),
+            BlockedStatus(
+                "Conflicting annotations from relations. Run juju debug-log for details. "
+                "Set manually via juju config."
+            ),
+        )
+
+    def test_on_ingress_relation_broken_conflict_routes(self):
+        """Test conflict routes error on ingress relation broken"""
+        self._run_on_ingress_relation_broken_exception(
+            ConflictingRoutesError(),
+            BlockedStatus(
+                "Duplicate route found; cannot add ingress. Run juju debug-log for details."
+            ),
+        ),
 
     @patch("charm.NginxIngressCharm._networking_v1_api")
     @patch("charm.NginxIngressCharm._core_v1_api")
@@ -855,6 +886,7 @@ class TestCharm(unittest.TestCase):
 
         mock_ingress = mock.Mock()
         mock_ingress.metadata.name = conf_or_rels[0]._ingress_name
+        mock_ingress.spec.rules = [unittest.mock.MagicMock(host=conf_or_rels[0]._service_hostname)]
         mock_ingresses = mock_net_api.return_value.list_namespaced_ingress.return_value
         mock_ingresses.items = [mock_ingress]
 
@@ -1544,11 +1576,8 @@ class TestCharmMultipleRelations(unittest.TestCase):
         relation = self.harness.charm.model.relations["ingress"][0]
         self.harness.charm.on.ingress_relation_broken.emit(relation)
 
-        mock_delete_service = mock_api.return_value.delete_namespaced_service
-        mock_delete_service.assert_called_once_with(
-            name=conf_or_rels[0]._k8s_service_name,
-            namespace=self.harness.charm._namespace,
-        )
+        _delete_unused_ingresses.assert_called()
+        _delete_unused_services.assert_called()
 
     @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
     @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
@@ -1659,7 +1688,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         mock_create_ingress.assert_not_called()
         mock_replace_ingress.assert_not_called()
-        mock_delete_ingress.assert_called_once()
+        _delete_unused_ingresses.assert_called()
 
     @patch("charm.NginxIngressCharm._delete_unused_ingresses", autospec=True)
     @patch("charm.NginxIngressCharm._delete_unused_services", autospec=True)
@@ -1752,12 +1781,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_replace_ingress.reset_mock()
         self.harness.remove_relation(rel_id1)
 
-        # Assert that only the ingress for the first relation was removed.
-        mock_delete_ingress = mock_api.return_value.delete_namespaced_ingress
-        mock_delete_ingress.assert_called_once_with(
-            conf_or_rels[0]._ingress_name,
-            self.harness.charm._namespace,
-        )
+        _delete_unused_ingresses.assert_called()
         mock_create_ingress.assert_not_called()
         expected_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
         mock_replace_ingress.assert_called_once_with(
@@ -1768,13 +1792,10 @@ class TestCharmMultipleRelations(unittest.TestCase):
 
         # Remove the second relation.
         mock_replace_ingress.reset_mock()
-        mock_delete_ingress.reset_mock()
+        _delete_unused_ingresses.reset_mock()
         self.harness.remove_relation(rel_id2)
 
-        mock_delete_ingress.assert_called_once_with(
-            conf_or_rels[1]._ingress_name,
-            self.harness.charm._namespace,
-        )
+        _delete_unused_ingresses.assert_called_once()
         mock_create_ingress.assert_not_called()
         mock_replace_ingress.assert_not_called()
 
@@ -1970,12 +1991,7 @@ class TestCharmMultipleRelations(unittest.TestCase):
         mock_replace_ingress.reset_mock()
         self.harness.remove_relation(rel_id1)
 
-        # Assert that only the ingress for the first relation was removed.
-        mock_delete_ingress = mock_api.return_value.delete_namespaced_ingress
-        mock_delete_ingress.assert_called_once_with(
-            conf_or_rels[0]._ingress_name,
-            self.harness.charm._namespace,
-        )
+        _delete_unused_ingresses.assert_called()
         mock_create_ingress.assert_not_called()
         expected_body = conf_or_rels[1]._get_k8s_ingress(label=self.harness.charm.app.name)
         mock_replace_ingress.assert_called_once_with(
@@ -2211,3 +2227,67 @@ class TestHelpers:
     )
     def test_invalid_hostname_check(self, hostname, expected):
         assert invalid_hostname_check(hostname) == expected
+
+
+class TestZeroDowntime(unittest.TestCase):
+    """Unit test cause for the zero downtime upgrade from ingress relation to nginx-route."""
+
+    def setUp(self) -> None:
+        """Test setup."""
+        self.harness = Harness(NginxIngressCharm)
+
+    def tearDown(self) -> None:
+        """Test cleanup"""
+        self.harness.cleanup()
+
+    def _relate_ingress(self, relation_data):
+        """Create a new ingress relation with given data.
+
+        Args:
+            relation_data: relation data to be set in the new relation.
+        """
+        relation_id = self.harness.add_relation("ingress", "app")
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="app/0")
+        self.harness.update_relation_data(relation_id, "app", relation_data)
+
+    def _relate_nginx_route(self, relation_data):
+        """Create a new nginx-route relation with given data.
+
+        Args:
+            relation_data: relation data to be set in the new relation.
+        """
+        relation_id = self.harness.add_relation("nginx-route", "app")
+        self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="app/0")
+        self.harness.update_relation_data(relation_id, "app", relation_data)
+
+    def test_dedup_relations(self):
+        relation_data = {
+            "service-hostname": "foo",
+            "service-name": "app",
+            "service-model": "test",
+            "service-port": "8080",
+        }
+        self._relate_ingress(relation_data)
+        self._relate_nginx_route(relation_data)
+        self.harness.begin()
+        self.assertEqual(len(self.harness.charm._deduped_relations()), 1)
+
+    def test_no_duplicate_relations(self):
+        self._relate_ingress(
+            {
+                "service-hostname": "foo",
+                "service-name": "app",
+                "service-model": "test",
+                "service-port": "8080",
+            }
+        )
+        self._relate_nginx_route(
+            {
+                "service-hostname": "foobar",
+                "service-name": "app",
+                "service-model": "test",
+                "service-port": "8080",
+            }
+        )
+        self.harness.begin()
+        self.assertEqual(len(self.harness.charm._deduped_relations()), 2)


### PR DESCRIPTION
This PR introduces the ability for mission-critical applications to seamlessly upgrade from the legacy `ingress` relation to the `nginx-route` relation without experiencing any downtime.

For applications opting to use this zero downtime transition:

1. The application should first prepare an intermediate revision that supports both `ingress` and `nginx-route` relations.
2. Upgrade the application charm to this intermediate revision.
3. Establish the `nginx-route` relation with the same relation data to `nginx-ingress-relation` while retaining the legacy `ingress` relation.
4. Ensure that all operations and processes are idle.
5. Safely remove the legacy `ingress` relation.
6. Refresh the application charm to the revision that exclusively supports `nginx-route`.

By following this sequence, applications can ensure a smooth transition with minimal risk and zero downtime.