### PR TITLE
Ignore broken relations during relation-broken events

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -570,7 +570,7 @@ class NginxIngressCharm(CharmBase):
         nginx_route_relations = [
             r for r in self.model.relations["nginx-route"] if r.app is not None
         ]
-        ingress_relations = [r for r in self.model.relations["ingress"] if r.data is not None]
+        ingress_relations = [r for r in self.model.relations["ingress"] if r.app is not None]
         nginx_route_relation_keys = set(
             self._gen_relation_dedup_key(r) for r in nginx_route_relations
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -567,8 +567,10 @@ class NginxIngressCharm(CharmBase):
         Returns:
             A relation list with duplicates removed.
         """
-        nginx_route_relations = self.model.relations["nginx-route"]
-        ingress_relations = self.model.relations["ingress"]
+        nginx_route_relations = [
+            r for r in self.model.relations["nginx-route"] if r.app is not None
+        ]
+        ingress_relations = [r for r in self.model.relations["ingress"] if r.data is not None]
         nginx_route_relation_keys = set(
             self._gen_relation_dedup_key(r) for r in nginx_route_relations
         )


### PR DESCRIPTION
When the `relation-broken` event is triggered, there's a possibility that the broken relation, although listed, the remote application may not be accessible. This update ensures such relations are safely ignored.

Fix: https://github.com/canonical/nginx-ingress-integrator-operator/issues/90