### PR TITLE
Adds ExternalName Service type option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -94,6 +94,12 @@ options:
     default: ""
     description: The path to rewrite requests to. If not set, rewrite-target will be "/".
     type: string
+  external-name:
+    default: ""
+    description: |
+      The external name of the service to create an ingress for.
+      The charm will create a Kubernetes ExternalName Service instead of a ClusterIP, allowing kubedns or equivalent to return it as a CNAME record.
+    type: string
   service-hostname:
     default: ""
     description: The hostname of the service to create an ingress for.

--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -12,6 +12,7 @@ Import `IngressRequires` in your charm, with two required options:
 `config_dict` accepts the following keys:
 - additional-hostnames
 - backend-protocol
+- external-name
 - limit-rps
 - limit-whitelist
 - max-body-size
@@ -89,7 +90,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 17
+LIBPATCH = 18
 
 LOGGER = logging.getLogger(__name__)
 
@@ -98,6 +99,7 @@ REQUIRED_INGRESS_RELATION_FIELDS = {"service-hostname", "service-name", "service
 OPTIONAL_INGRESS_RELATION_FIELDS = {
     "additional-hostnames",
     "backend-protocol",
+    "external-hostname",
     "limit-rps",
     "limit-whitelist",
     "max-body-size",


### PR DESCRIPTION
Kubernetes has a Service type `ExternalName`, which allows the Cluster DNS Service to return a CNAME record to the set  `externalName`. This can be useful in certain situations.

The `nginx-ingress-integrator` charm does not have any support for this at this moment.

This commit adds the `external-name` relation field and config option, which, if set, will cause the `nginx-ingress-integrator` charm to create a Kubernetes ExternalName Service with the `externalName` set instead of a ClusterIP Service.

Implements: https://github.com/canonical/nginx-ingress-integrator-operator/issues/93