### PR TITLE
Match port names across ingress related objects

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -256,7 +256,11 @@ class EndpointsController(ResourceController[kubernetes.client.V1Endpoints]):
                         kubernetes.client.V1EndpointAddress(ip=endpoint)
                         for endpoint in definition.upstream_endpoints
                     ],
-                    ports=[kubernetes.client.CoreV1EndpointPort(port=definition.service_port)],
+                    ports=[
+                        kubernetes.client.CoreV1EndpointPort(
+                            name=definition.port_name, port=definition.service_port
+                        )
+                    ],
                 )
             ],
         )
@@ -358,7 +362,7 @@ class EndpointSliceController(ResourceController[kubernetes.client.V1EndpointSli
             address_type=address_type,
             ports=[
                 kubernetes.client.DiscoveryV1EndpointPort(
-                    name=f"endpoint-tcp-{definition.service_port}",
+                    name=definition.port_name,
                     port=definition.service_port,
                 )
             ],
@@ -510,7 +514,7 @@ class ServiceController(ResourceController[kubernetes.client.V1Service]):
         spec = kubernetes.client.V1ServiceSpec(
             ports=[
                 kubernetes.client.V1ServicePort(
-                    name=f"tcp-{definition.service_port}",
+                    name=definition.port_name,
                     port=definition.service_port,
                     target_port=definition.service_port,
                 )

--- a/src/ingress_definition.py
+++ b/src/ingress_definition.py
@@ -549,3 +549,8 @@ class IngressDefinition:  # pylint: disable=too-many-public-methods,too-many-ins
             use_endpoint_slice=essence.use_endpoint_slice,
             whitelist_source_range=essence.whitelist_source_range,
         )
+
+    @property
+    def port_name(self) -> str:
+        """Return the port name for ingress related objects."""
+        return f"tcp-{self.service_port}"

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -115,3 +115,20 @@ def test_update_ingress_ip(k8s_stub: K8sStub, harness: Harness, ingress_relation
     assert k8s_stub.get_endpoint_slices(TEST_NAMESPACE) == []
     assert k8s_stub.get_services(TEST_NAMESPACE) == []
     assert k8s_stub.get_ingresses(TEST_NAMESPACE) == []
+
+
+def test_port_name(k8s_stub: K8sStub, harness: Harness, ingress_relation):
+    """
+    arrange: set up test harness and ingress relation.
+    act: update the ingress relation with basic data.
+    assert: port names are the same across all ingress related objects.
+    """
+    harness.begin()
+    ingress_relation.update_app_data(ingress_relation.gen_example_app_data())
+    ingress_relation.update_unit_data(ingress_relation.gen_example_unit_data())
+    harness.update_config({"service-hostname": "example.com"})
+    assert (
+        k8s_stub.get_services(TEST_NAMESPACE)[0].spec.ports[0].name
+        == k8s_stub.get_endpoints(TEST_NAMESPACE)[0].subsets[0].ports[0].name
+        == k8s_stub.get_endpoint_slices(TEST_NAMESPACE)[0].ports[0].name
+    )


### PR DESCRIPTION
Certain versions of the Nginx ingress controller are unable to resolve the endpoints of a service when the port names in the service definition and endpoints definition differ. To address this, update the charm to ensure the port names align across all ingress related objects.