### PR TITLE
Update charmcraft.yaml to declare arm64 support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,3 +8,7 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+      architectures:
+        - amd64
+        - aarch64
+        - arm64


### PR DESCRIPTION
The `nginx-ingress-integrator` charm is using pure Python, thereby it *should* compatibility with arm64 architectures. This pull request introduces the declarations to enable deployment on arm64 machines.