### PR TITLE
Add the disable-access-log option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,10 @@ options:
       Indicates how NGINX should communicate with the backend service. Valid
       Values: HTTP, HTTPS, GRPC, GRPCS, AJP and FCGI.
     type: string
+  disable-access-log:
+    description: >
+      Setting this to true disables access log for the ingress using nginx.ingress.kubernetes.io/enable-access-log.
+    type: boolean
   ingress-class:
     default: ""
     description: |

--- a/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
+++ b/lib/charms/nginx_ingress_integrator/v0/nginx_route.py
@@ -86,7 +86,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 __all__ = ["require_nginx_route", "provide_nginx_route"]
 
@@ -181,6 +181,7 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
     service_port: int,
     additional_hostnames: typing.Optional[str] = None,
     backend_protocol: typing.Optional[str] = None,
+    disable_access_log: bool = False,
     limit_rps: typing.Optional[int] = None,
     limit_whitelist: typing.Optional[str] = None,
     max_body_size: typing.Optional[int] = None,
@@ -211,6 +212,8 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
             additional-hostnames option via relation, optional.
         backend_protocol: configure Nginx ingress integrator
             backend-protocol option via relation, optional.
+        disable_access_log: disable access logs with
+            nginx.ingress.kubernetes.io/enable-access-log option.
         limit_rps: configure Nginx ingress integrator limit-rps
             option via relation, optional.
         limit_whitelist: configure Nginx ingress integrator
@@ -251,6 +254,8 @@ def require_nginx_route(  # pylint: disable=too-many-locals,too-many-branches,to
         config["additional-hostnames"] = additional_hostnames
     if backend_protocol is not None:
         config["backend-protocol"] = backend_protocol
+    if disable_access_log:
+        config["disable-access-log"] = "true"
     if limit_rps is not None:
         config["limit-rps"] = limit_rps
     if limit_whitelist is not None:

--- a/src/controller/ingress.py
+++ b/src/controller/ingress.py
@@ -95,8 +95,10 @@ class IngressController(
 
         body.spec.ingress_class_name = ingress_class
 
+    # disable the "function is too complex" warning here
+    # this function is actually quite straightforward
     @_map_k8s_auth_exception
-    def _gen_resource_from_definition(
+    def _gen_resource_from_definition(  # noqa: C901
         self, definition: IngressDefinition
     ) -> kubernetes.client.V1Ingress:
         """Generate a V1Ingress resource from ingress definition.
@@ -139,6 +141,8 @@ class IngressController(
             "nginx.ingress.kubernetes.io/proxy-read-timeout": definition.proxy_read_timeout,
             "nginx.ingress.kubernetes.io/backend-protocol": definition.backend_protocol,
         }
+        if definition.disable_access_log:
+            annotations["nginx.ingress.kubernetes.io/enable-access-log"] = "false"
         if definition.limit_rps:
             annotations["nginx.ingress.kubernetes.io/limit-rps"] = definition.limit_rps
             if definition.limit_whitelist:

--- a/src/ingress_definition.py
+++ b/src/ingress_definition.py
@@ -213,6 +213,20 @@ class IngressDefinitionEssence:  # pylint: disable=too-many-public-methods
         return backend_protocol
 
     @property
+    def disable_access_log(self) -> bool:
+        """Return if access log is disabled for this ingress.
+
+        If the charm configuration is set, it takes precedence over the relation data.
+        If this setting is not specified in the configuration or relation, it defaults to False.
+        """
+        relation_data = self._get_relation("disable-access-log")
+        from_relation = relation_data.lower() == "true" if relation_data is not None else None
+        from_config = self._get_config("disable-access-log")
+        if from_config is None:
+            return bool(from_relation)
+        return bool(from_config)
+
+    @property
     def k8s_endpoint_slice_name(self) -> str:
         """Return the endpoint slice name for the use creating a k8s endpoint slice."""
         # endpoint slice name must be the same as service name
@@ -508,6 +522,7 @@ class IngressDefinition:  # pylint: disable=too-many-public-methods,too-many-ins
 
     additional_hostnames: List[str]
     backend_protocol: str
+    disable_access_log: bool
     ingress_class: Optional[str]
     is_ingress_relation: bool
     k8s_endpoint_slice_name: str
@@ -552,6 +567,7 @@ class IngressDefinition:  # pylint: disable=too-many-public-methods,too-many-ins
         return cls(
             additional_hostnames=essence.additional_hostnames,
             backend_protocol=essence.backend_protocol,
+            disable_access_log=essence.disable_access_log,
             ingress_class=essence.ingress_class,
             is_ingress_relation=essence.is_ingress_relation,
             k8s_endpoint_slice_name=essence.k8s_endpoint_slice_name,

--- a/tests/unit/test_nginx_route.py
+++ b/tests/unit/test_nginx_route.py
@@ -151,6 +151,31 @@ def test_backend_protocol_error(k8s_stub: K8sStub, harness: Harness, nginx_route
     assert harness.charm.unit.status.name == "blocked"
 
 
+def test_disable_access_log(k8s_stub: K8sStub, harness: Harness, nginx_route_relation):
+    """
+    arrange: set up test harness and nginx-route relation.
+    act: set the disable-access-log in the nginx-route relation.
+    assert: ingress annotations are updated according to the disable-access-log value.
+    """
+    relation_data = nginx_route_relation.gen_example_app_data()
+    harness.begin()
+    nginx_route_relation.update_app_data(relation_data)
+    ingress = k8s_stub.get_ingresses(TEST_NAMESPACE)[0]
+    assert "nginx.ingress.kubernetes.io/enable-access-log" not in ingress.metadata.annotations
+    relation_data["disable-access-log"] = "true"
+    nginx_route_relation.update_app_data(relation_data)
+    ingress = k8s_stub.get_ingresses(TEST_NAMESPACE)[0]
+    assert ingress.metadata.annotations["nginx.ingress.kubernetes.io/enable-access-log"] == "false"
+    relation_data["disable-access-log"] = "false"
+    nginx_route_relation.update_app_data(relation_data)
+    ingress = k8s_stub.get_ingresses(TEST_NAMESPACE)[0]
+    assert "nginx.ingress.kubernetes.io/enable-access-log" not in ingress.metadata.annotations
+    harness.update_config({"disable-access-log": True})
+    nginx_route_relation.update_app_data(relation_data)
+    ingress = k8s_stub.get_ingresses(TEST_NAMESPACE)[0]
+    assert ingress.metadata.annotations["nginx.ingress.kubernetes.io/enable-access-log"] == "false"
+
+
 def test_ingress_class(k8s_stub: K8sStub, harness: Harness, nginx_route_relation):
     """
     arrange: set up test harness and nginx-route relation.


### PR DESCRIPTION
Add a new option, `disable-access-log`, to control the `nginx.ingress.kubernetes.io/enable-access-log` annotation on ingress resources. 

Since this option is boolean value, flip the name to `disable-access-log` to ensure that the null value defaults to enabling the access log, which aligns with the default value of `nginx.ingress.kubernetes.io/enable-access-log` annotation.

fulfill: https://github.com/canonical/nginx-ingress-integrator-operator/issues/111