### PR TITLE
Upgrade to v3 and get full cert chain

### DIFF
--- a/lib/charms/nginx_ingress_integrator/v0/ingress.py
+++ b/lib/charms/nginx_ingress_integrator/v0/ingress.py
@@ -261,9 +261,8 @@ class IngressRequires(Object):
         if self.model.unit.is_leader():
             if self._config_dict_errors(config_dict=self.config_dict):
                 return
-            event.relation.data[self.model.app].update(
-                (key, str(self.config_dict[key])) for key in self.config_dict
-            )
+            relation_dict = {key: str(self.config_dict[key]) for key in self.config_dict}
+            event.relation.data[self.model.app].update(relation_dict)
 
     def update_config(self, config_dict: Dict) -> None:
         """Allow for updates to relation.

--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 
@@ -7,16 +7,19 @@
 This library contains the Requires and Provides classes for handling the tls-certificates
 interface.
 
+Pre-requisites:
+  - Juju >= 3.0
+
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.tls_certificates_interface.v2.tls_certificates
+charmcraft fetch-lib charms.tls_certificates_interface.v3.tls_certificates
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
 - jsonschema
-- cryptography
+- cryptography >= 42.0.0
 
 Add the following section to the charm's `charmcraft.yaml` file:
 ```yaml
@@ -36,10 +39,10 @@ this example, the provider charm is storing its private key using a peer relatio
 
 Example:
 ```python
-from charms.tls_certificates_interface.v2.tls_certificates import (
+from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateCreationRequestEvent,
     CertificateRevocationRequestEvent,
-    TLSCertificatesProvidesV2,
+    TLSCertificatesProvidesV3,
     generate_private_key,
 )
 from ops.charm import CharmBase, InstallEvent
@@ -59,7 +62,7 @@ class ExampleProviderCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.certificates = TLSCertificatesProvidesV2(self, "certificates")
+        self.certificates = TLSCertificatesProvidesV3(self, "certificates")
         self.framework.observe(
             self.certificates.on.certificate_request,
             self._on_certificate_request
@@ -108,6 +111,7 @@ class ExampleProviderCharm(CharmBase):
             ca=ca_certificate,
             chain=[ca_certificate, certificate],
             relation_id=event.relation_id,
+            recommended_expiry_notification_time=720,
         )
 
     def _on_certificate_revocation_request(self, event: CertificateRevocationRequestEvent) -> None:
@@ -126,15 +130,15 @@ this example, the requirer charm is storing its certificates using a peer relati
 
 Example:
 ```python
-from charms.tls_certificates_interface.v2.tls_certificates import (
+from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateAvailableEvent,
     CertificateExpiringEvent,
     CertificateRevokedEvent,
-    TLSCertificatesRequiresV2,
+    TLSCertificatesRequiresV3,
     generate_csr,
     generate_private_key,
 )
-from ops.charm import CharmBase, RelationJoinedEvent
+from ops.charm import CharmBase, RelationCreatedEvent
 from ops.main import main
 from ops.model import ActiveStatus, WaitingStatus
 from typing import Union
@@ -145,10 +149,10 @@ class ExampleRequirerCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self.cert_subject = "whatever"
-        self.certificates = TLSCertificatesRequiresV2(self, "certificates")
+        self.certificates = TLSCertificatesRequiresV3(self, "certificates")
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(
-            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+            self.on.certificates_relation_created, self._on_certificates_relation_created
         )
         self.framework.observe(
             self.certificates.on.certificate_available, self._on_certificate_available
@@ -176,7 +180,7 @@ class ExampleRequirerCharm(CharmBase):
             {"private_key_password": "banana", "private_key": private_key.decode()}
         )
 
-    def _on_certificates_relation_joined(self, event: RelationJoinedEvent) -> None:
+    def _on_certificates_relation_created(self, event: RelationCreatedEvent) -> None:
         replicas_relation = self.model.get_relation("replicas")
         if not replicas_relation:
             self.unit.status = WaitingStatus("Waiting for peer relation to be created")
@@ -277,15 +281,15 @@ import json
 import logging
 import uuid
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from cryptography import x509
 from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives.serialization import pkcs12
 from jsonschema import exceptions, validate
 from ops.charm import (
     CharmBase,
@@ -293,21 +297,27 @@ from ops.charm import (
     RelationBrokenEvent,
     RelationChangedEvent,
     SecretExpiredEvent,
-    UpdateStatusEvent,
 )
 from ops.framework import EventBase, EventSource, Handle, Object
 from ops.jujuversion import JujuVersion
-from ops.model import ModelError, Relation, RelationDataContent, SecretNotFoundError
+from ops.model import (
+    Application,
+    ModelError,
+    Relation,
+    RelationDataContent,
+    SecretNotFoundError,
+    Unit,
+)
 
 # The unique Charmhub library identifier, never change it
 LIBID = "afd8c2bccf834997afce12c2706d2ede"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 2
+LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 28
+LIBPATCH = 13
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -422,6 +432,58 @@ PROVIDER_JSON_SCHEMA = {
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class RequirerCSR:
+    """This class represents a certificate signing request from an interface Requirer."""
+
+    relation_id: int
+    application_name: str
+    unit_name: str
+    csr: str
+    is_ca: bool
+
+
+@dataclass
+class ProviderCertificate:
+    """This class represents a certificate from an interface Provider."""
+
+    relation_id: int
+    application_name: str
+    csr: str
+    certificate: str
+    ca: str
+    chain: List[str]
+    revoked: bool
+    expiry_time: datetime
+    expiry_notification_time: Optional[datetime] = None
+
+    def chain_as_pem(self) -> str:
+        """Return full certificate chain as a PEM string."""
+        return "\n\n".join(reversed(self.chain))
+
+    def to_json(self) -> str:
+        """Return the object as a JSON string.
+
+        Returns:
+            str: JSON representation of the object
+        """
+        return json.dumps(
+            {
+                "relation_id": self.relation_id,
+                "application_name": self.application_name,
+                "csr": self.csr,
+                "certificate": self.certificate,
+                "ca": self.ca,
+                "chain": self.chain,
+                "revoked": self.revoked,
+                "expiry_time": self.expiry_time.isoformat(),
+                "expiry_notification_time": self.expiry_notification_time.isoformat()
+                if self.expiry_notification_time
+                else None,
+            }
+        )
+
+
 class CertificateAvailableEvent(EventBase):
     """Charm Event triggered when a TLS certificate is available."""
 
@@ -454,6 +516,10 @@ class CertificateAvailableEvent(EventBase):
         self.certificate_signing_request = snapshot["certificate_signing_request"]
         self.ca = snapshot["ca"]
         self.chain = snapshot["chain"]
+
+    def chain_as_pem(self) -> str:
+        """Return full certificate chain as a PEM string."""
+        return "\n\n".join(reversed(self.chain))
 
 
 class CertificateExpiringEvent(EventBase):
@@ -641,21 +707,49 @@ def _get_closest_future_time(
     )
 
 
-def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
-    """Extract expiry time from a certificate string.
+def calculate_expiry_notification_time(
+    validity_start_time: datetime,
+    expiry_time: datetime,
+    provider_recommended_notification_time: Optional[int],
+    requirer_recommended_notification_time: Optional[int],
+) -> datetime:
+    """Calculate a reasonable time to notify the user about the certificate expiry.
+
+    It takes into account the time recommended by the provider and by the requirer.
+    Time recommended by the provider is preferred,
+    then time recommended by the requirer,
+    then dynamically calculated time.
 
     Args:
-        certificate (str): x509 certificate as a string
+        validity_start_time: Certificate validity time
+        expiry_time: Certificate expiry time
+        provider_recommended_notification_time:
+            Time in hours prior to expiry to notify the user.
+            Recommended by the provider.
+        requirer_recommended_notification_time:
+            Time in hours prior to expiry to notify the user.
+            Recommended by the requirer.
 
     Returns:
-        Optional[datetime]: Expiry datetime or None
+        datetime: Time to notify the user about the certificate expiry.
     """
-    try:
-        certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
-        return certificate_object.not_valid_after_utc
-    except ValueError:
-        logger.warning("Could not load certificate.")
-        return None
+    if provider_recommended_notification_time is not None:
+        provider_recommended_notification_time = abs(provider_recommended_notification_time)
+        provider_recommendation_time_delta = (
+            expiry_time - timedelta(hours=provider_recommended_notification_time)
+        )
+        if validity_start_time < provider_recommendation_time_delta:
+            return provider_recommendation_time_delta
+
+    if requirer_recommended_notification_time is not None:
+        requirer_recommended_notification_time = abs(requirer_recommended_notification_time)
+        requirer_recommendation_time_delta = (
+            expiry_time - timedelta(hours=requirer_recommended_notification_time)
+        )
+        if validity_start_time < requirer_recommendation_time_delta:
+            return requirer_recommendation_time_delta
+    calculated_hours = (expiry_time - validity_start_time).total_seconds() / (3600 * 3)
+    return expiry_time - timedelta(hours=calculated_hours)
 
 
 def generate_ca(
@@ -886,38 +980,6 @@ def generate_certificate(
     return cert.public_bytes(serialization.Encoding.PEM)
 
 
-def generate_pfx_package(
-    certificate: bytes,
-    private_key: bytes,
-    package_password: str,
-    private_key_password: Optional[bytes] = None,
-) -> bytes:
-    """Generate a PFX package to contain the TLS certificate and private key.
-
-    Args:
-        certificate (bytes): TLS certificate
-        private_key (bytes): Private key
-        package_password (str): Password to open the PFX package
-        private_key_password (bytes): Private key password
-
-    Returns:
-        bytes:
-    """
-    private_key_object = serialization.load_pem_private_key(
-        private_key, password=private_key_password
-    )
-    certificate_object = x509.load_pem_x509_certificate(certificate)
-    name = certificate_object.subject.rfc4514_string()
-    pfx_bytes = pkcs12.serialize_key_and_certificates(
-        name=name.encode(),
-        cert=certificate_object,
-        key=private_key_object,  # type: ignore[arg-type]
-        cas=None,
-        encryption_algorithm=serialization.BestAvailableEncryption(package_password.encode()),
-    )
-    return pfx_bytes
-
-
 def generate_private_key(
     password: Optional[bytes] = None,
     key_size: int = 2048,
@@ -956,6 +1018,8 @@ def generate_csr(  # noqa: C901
     organization: Optional[str] = None,
     email_address: Optional[str] = None,
     country_name: Optional[str] = None,
+    state_or_province_name: Optional[str] = None,
+    locality_name: Optional[str] = None,
     private_key_password: Optional[bytes] = None,
     sans: Optional[List[str]] = None,
     sans_oid: Optional[List[str]] = None,
@@ -974,6 +1038,8 @@ def generate_csr(  # noqa: C901
         organization (str): Name of organization.
         email_address (str): Email address.
         country_name (str): Country Name.
+        state_or_province_name (str): State or Province Name.
+        locality_name (str): Locality Name.
         private_key_password (bytes): Private key password
         sans (list): Use sans_dns - this will be deprecated in a future release
             List of DNS subject alternative names (keeping it for now for backward compatibility)
@@ -999,6 +1065,12 @@ def generate_csr(  # noqa: C901
         subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
     if country_name:
         subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    if state_or_province_name:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state_or_province_name)
+        )
+    if locality_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, locality_name))
     csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
 
     _sans: List[x509.GeneralName] = []
@@ -1053,6 +1125,27 @@ def csr_matches_certificate(csr: str, cert: str) -> bool:
     return True
 
 
+def _relation_data_is_valid(
+    relation: Relation, app_or_unit: Union[Application, Unit], json_schema: dict
+) -> bool:
+    """Check whether relation data is valid based on json schema.
+
+    Args:
+        relation (Relation): Relation object
+        app_or_unit (Union[Application, Unit]): Application or unit object
+        json_schema (dict): Json schema
+
+    Returns:
+        bool: Whether relation data is valid.
+    """
+    relation_data = _load_relation_data(relation.data[app_or_unit])
+    try:
+        validate(instance=relation_data, schema=json_schema)
+        return True
+    except exceptions.ValidationError:
+        return False
+
+
 class CertificatesProviderCharmEvents(CharmEvents):
     """List of events that the TLS Certificates provider charm can leverage."""
 
@@ -1069,7 +1162,7 @@ class CertificatesRequirerCharmEvents(CharmEvents):
     all_certificates_invalidated = EventSource(AllCertificatesInvalidatedEvent)
 
 
-class TLSCertificatesProvidesV2(Object):
+class TLSCertificatesProvidesV3(Object):
     """TLS certificates provider class to be instantiated by TLS certificates providers."""
 
     on = CertificatesProviderCharmEvents()  # type: ignore[reportAssignmentType]
@@ -1105,6 +1198,7 @@ class TLSCertificatesProvidesV2(Object):
         certificate_signing_request: str,
         ca: str,
         chain: List[str],
+        recommended_expiry_notification_time: Optional[int] = None,
     ) -> None:
         """Add certificate to relation data.
 
@@ -1114,6 +1208,8 @@ class TLSCertificatesProvidesV2(Object):
             certificate_signing_request (str): Certificate Signing Request
             ca (str): CA Certificate
             chain (list): CA Chain
+            recommended_expiry_notification_time (int):
+                Time in hours before the certificate expires to notify the user.
 
         Returns:
             None
@@ -1131,6 +1227,7 @@ class TLSCertificatesProvidesV2(Object):
             "certificate_signing_request": certificate_signing_request,
             "ca": ca,
             "chain": chain,
+            "recommended_expiry_notification_time": recommended_expiry_notification_time,
         }
         provider_relation_data = self._load_app_relation_data(relation)
         provider_certificates = provider_relation_data.get("certificates", [])
@@ -1178,22 +1275,6 @@ class TLSCertificatesProvidesV2(Object):
                 certificates.remove(certificate_dict)
         relation.data[self.model.app]["certificates"] = json.dumps(certificates)
 
-    @staticmethod
-    def _relation_data_is_valid(certificates_data: dict) -> bool:
-        """Use JSON schema validator to validate relation data content.
-
-        Args:
-            certificates_data (dict): Certificate data dictionary as retrieved from relation data.
-
-        Returns:
-            bool: True/False depending on whether the relation data follows the json schema.
-        """
-        try:
-            validate(instance=certificates_data, schema=REQUIRER_JSON_SCHEMA)
-            return True
-        except exceptions.ValidationError:
-            return False
-
     def revoke_all_certificates(self) -> None:
         """Revoke all certificates of this provider.
 
@@ -1213,6 +1294,7 @@ class TLSCertificatesProvidesV2(Object):
         ca: str,
         chain: List[str],
         relation_id: int,
+        recommended_expiry_notification_time: Optional[int] = None,
     ) -> None:
         """Add certificates to relation data.
 
@@ -1222,6 +1304,8 @@ class TLSCertificatesProvidesV2(Object):
             ca (str): CA Certificate
             chain (list): CA Chain
             relation_id (int): Juju relation ID
+            recommended_expiry_notification_time (int):
+                Recommended time in hours before the certificate expires to notify the user.
 
         Returns:
             None
@@ -1243,6 +1327,7 @@ class TLSCertificatesProvidesV2(Object):
             certificate_signing_request=certificate_signing_request.strip(),
             ca=ca.strip(),
             chain=[cert.strip() for cert in chain],
+            recommended_expiry_notification_time=recommended_expiry_notification_time,
         )
 
     def remove_certificate(self, certificate: str) -> None:
@@ -1262,16 +1347,24 @@ class TLSCertificatesProvidesV2(Object):
 
     def get_issued_certificates(
         self, relation_id: Optional[int] = None
-    ) -> Dict[str, List[Dict[str, str]]]:
-        """Return a dictionary of issued certificates.
-
-        It returns certificates from all relations if relation_id is not specified.
-        Certificates are returned per application name and CSR.
+    ) -> List[ProviderCertificate]:
+        """Return a List of issued (non revoked) certificates.
 
         Returns:
-            dict: Certificates per application name.
+            List: List of ProviderCertificate objects
         """
-        certificates: Dict[str, List[Dict[str, str]]] = {}
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
+        return [certificate for certificate in provider_certificates if not certificate.revoked]
+
+    def get_provider_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return a List of issued certificates.
+
+        Returns:
+            List: List of ProviderCertificate objects
+        """
+        certificates: List[ProviderCertificate] = []
         relations = (
             [
                 relation
@@ -1282,19 +1375,33 @@ class TLSCertificatesProvidesV2(Object):
             else self.model.relations.get(self.relationship_name, [])
         )
         for relation in relations:
+            if not relation.app:
+                logger.warning("Relation %s does not have an application", relation.id)
+                continue
             provider_relation_data = self._load_app_relation_data(relation)
             provider_certificates = provider_relation_data.get("certificates", [])
-
-            certificates[relation.app.name] = []  # type: ignore[union-attr]
             for certificate in provider_certificates:
-                if not certificate.get("revoked", False):
-                    certificates[relation.app.name].append(  # type: ignore[union-attr]
-                        {
-                            "csr": certificate["certificate_signing_request"],
-                            "certificate": certificate["certificate"],
-                        }
+                try:
+                    certificate_object = x509.load_pem_x509_certificate(
+                        data=certificate["certificate"].encode()
                     )
-
+                except ValueError as e:
+                    logger.error("Could not load certificate - Skipping: %s", e)
+                    continue
+                provider_certificate = ProviderCertificate(
+                    relation_id=relation.id,
+                    application_name=relation.app.name,
+                    csr=certificate["certificate_signing_request"],
+                    certificate=certificate["certificate"],
+                    ca=certificate["ca"],
+                    chain=certificate["chain"],
+                    revoked=certificate.get("revoked", False),
+                    expiry_time=certificate_object.not_valid_after_utc,
+                    expiry_notification_time=certificate.get(
+                        "recommended_expiry_notification_time"
+                    ),
+                )
+                certificates.append(provider_certificate)
         return certificates
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
@@ -1317,124 +1424,77 @@ class TLSCertificatesProvidesV2(Object):
             return
         if not self.model.unit.is_leader():
             return
-        requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
-        provider_relation_data = self._load_app_relation_data(event.relation)
-        if not self._relation_data_is_valid(requirer_relation_data):
+        if not _relation_data_is_valid(event.relation, event.unit, REQUIRER_JSON_SCHEMA):
             logger.debug("Relation data did not pass JSON Schema validation")
             return
-        provider_certificates = provider_relation_data.get("certificates", [])
-        requirer_csrs = requirer_relation_data.get("certificate_signing_requests", [])
+        provider_certificates = self.get_provider_certificates(relation_id=event.relation.id)
+        requirer_csrs = self.get_requirer_csrs(relation_id=event.relation.id)
         provider_csrs = [
-            certificate_creation_request["certificate_signing_request"]
+            certificate_creation_request.csr
             for certificate_creation_request in provider_certificates
         ]
-        requirer_unit_certificate_requests = [
-            {
-                "csr": certificate_creation_request["certificate_signing_request"],
-                "is_ca": certificate_creation_request.get("ca", False),
-            }
-            for certificate_creation_request in requirer_csrs
-        ]
-        for certificate_request in requirer_unit_certificate_requests:
-            if certificate_request["csr"] not in provider_csrs:
+        for certificate_request in requirer_csrs:
+            if certificate_request.csr not in provider_csrs:
                 self.on.certificate_creation_request.emit(
-                    certificate_signing_request=certificate_request["csr"],
-                    relation_id=event.relation.id,
-                    is_ca=certificate_request["is_ca"],
+                    certificate_signing_request=certificate_request.csr,
+                    relation_id=certificate_request.relation_id,
+                    is_ca=certificate_request.is_ca,
                 )
         self._revoke_certificates_for_which_no_csr_exists(relation_id=event.relation.id)
 
     def _revoke_certificates_for_which_no_csr_exists(self, relation_id: int) -> None:
         """Revoke certificates for which no unit has a CSR.
 
-        Goes through all generated certificates and compare against the list of CSRs for all units
-        of a given relationship.
-
-        Args:
-            relation_id (int): Relation id
+        Goes through all generated certificates and compare against the list of CSRs for all units.
 
         Returns:
             None
         """
-        certificates_relation = self.model.get_relation(
-            relation_name=self.relationship_name, relation_id=relation_id
-        )
-        if not certificates_relation:
-            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
-        provider_relation_data = self._load_app_relation_data(certificates_relation)
-        list_of_csrs: List[str] = []
-        for unit in certificates_relation.units:
-            requirer_relation_data = _load_relation_data(certificates_relation.data[unit])
-            requirer_csrs = requirer_relation_data.get("certificate_signing_requests", [])
-            list_of_csrs.extend(csr["certificate_signing_request"] for csr in requirer_csrs)
-        provider_certificates = provider_relation_data.get("certificates", [])
+        provider_certificates = self.get_provider_certificates(relation_id)
+        requirer_csrs = self.get_requirer_csrs(relation_id)
+        list_of_csrs = [csr.csr for csr in requirer_csrs]
         for certificate in provider_certificates:
-            if certificate["certificate_signing_request"] not in list_of_csrs:
+            if certificate.csr not in list_of_csrs:
                 self.on.certificate_revocation_request.emit(
-                    certificate=certificate["certificate"],
-                    certificate_signing_request=certificate["certificate_signing_request"],
-                    ca=certificate["ca"],
-                    chain=certificate["chain"],
+                    certificate=certificate.certificate,
+                    certificate_signing_request=certificate.csr,
+                    ca=certificate.ca,
+                    chain=certificate.chain,
                 )
-                self.remove_certificate(certificate=certificate["certificate"])
+                self.remove_certificate(certificate=certificate.certificate)
 
     def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None
-    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
+    ) -> List[RequirerCSR]:
         """Return CSR's for which no certificate has been issued.
-
-        Example return: [
-            {
-                "relation_id": 0,
-                "application_name": "tls-certificates-requirer",
-                "unit_name": "tls-certificates-requirer/0",
-                "unit_csrs": [
-                    {
-                        "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
-                        "is_ca": false
-                    }
-                ]
-            }
-        ]
 
         Args:
             relation_id (int): Relation id
 
         Returns:
-            list: List of dictionaries that contain the unit's csrs
-            that don't have a certificate issued.
+            list: List of RequirerCSR objects.
         """
-        all_unit_csr_mappings = copy.deepcopy(self.get_requirer_csrs(relation_id=relation_id))
-        filtered_all_unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
-        for unit_csr_mapping in all_unit_csr_mappings:
-            csrs_without_certs = []
-            for csr in unit_csr_mapping["unit_csrs"]:  # type: ignore[union-attr]
-                if not self.certificate_issued_for_csr(
-                    app_name=unit_csr_mapping["application_name"],  # type: ignore[arg-type]
-                    csr=csr["certificate_signing_request"],  # type: ignore[index]
-                    relation_id=relation_id,
-                ):
-                    csrs_without_certs.append(csr)
-            if csrs_without_certs:
-                unit_csr_mapping["unit_csrs"] = csrs_without_certs  # type: ignore[assignment]
-                filtered_all_unit_csr_mappings.append(unit_csr_mapping)
-        return filtered_all_unit_csr_mappings
+        requirer_csrs = self.get_requirer_csrs(relation_id=relation_id)
+        outstanding_csrs: List[RequirerCSR] = []
+        for relation_csr in requirer_csrs:
+            if not self.certificate_issued_for_csr(
+                app_name=relation_csr.application_name,
+                csr=relation_csr.csr,
+                relation_id=relation_id,
+            ):
+                outstanding_csrs.append(relation_csr)
+        return outstanding_csrs
 
-    def get_requirer_csrs(
-        self, relation_id: Optional[int] = None
-    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
-        """Return a list of requirers' CSRs grouped by unit.
+    def get_requirer_csrs(self, relation_id: Optional[int] = None) -> List[RequirerCSR]:
+        """Return a list of requirers' CSRs.
 
         It returns CSRs from all relations if relation_id is not specified.
         CSRs are returned per relation id, application name and unit name.
 
         Returns:
-            list: List of dictionaries that contain the unit's csrs
-            with the following information
-            relation_id, application_name and unit_name.
+            list: List[RequirerCSR]
         """
-        unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
-
+        relation_csrs: List[RequirerCSR] = []
         relations = (
             [
                 relation
@@ -1449,15 +1509,24 @@ class TLSCertificatesProvidesV2(Object):
             for unit in relation.units:
                 requirer_relation_data = _load_relation_data(relation.data[unit])
                 unit_csrs_list = requirer_relation_data.get("certificate_signing_requests", [])
-                unit_csr_mappings.append(
-                    {
-                        "relation_id": relation.id,
-                        "application_name": relation.app.name,  # type: ignore[union-attr]
-                        "unit_name": unit.name,
-                        "unit_csrs": unit_csrs_list,
-                    }
-                )
-        return unit_csr_mappings
+                for unit_csr in unit_csrs_list:
+                    csr = unit_csr.get("certificate_signing_request")
+                    if not csr:
+                        logger.warning("No CSR found in relation data - Skipping")
+                        continue
+                    ca = unit_csr.get("ca", False)
+                    if not relation.app:
+                        logger.warning("No remote app in relation - Skipping")
+                        continue
+                    relation_csr = RequirerCSR(
+                        relation_id=relation.id,
+                        application_name=relation.app.name,
+                        unit_name=unit.name,
+                        csr=csr,
+                        is_ca=ca,
+                    )
+                    relation_csrs.append(relation_csr)
+        return relation_csrs
 
     def certificate_issued_for_csr(
         self, app_name: str, csr: str, relation_id: Optional[int]
@@ -1468,19 +1537,18 @@ class TLSCertificatesProvidesV2(Object):
             app_name (str): Application name that the CSR belongs to.
             csr (str): Certificate Signing Request.
             relation_id (Optional[int]): Relation ID
+
         Returns:
             bool: True/False depending on whether a certificate has been issued for the given CSR.
         """
-        issued_certificates_per_csr = self.get_issued_certificates(relation_id=relation_id)[
-            app_name
-        ]
-        for issued_pair in issued_certificates_per_csr:
-            if "csr" in issued_pair and issued_pair["csr"] == csr:
-                return csr_matches_certificate(csr, issued_pair["certificate"])
+        issued_certificates_per_csr = self.get_issued_certificates(relation_id=relation_id)
+        for issued_certificate in issued_certificates_per_csr:
+            if issued_certificate.csr == csr and issued_certificate.application_name == app_name:
+                return csr_matches_certificate(csr, issued_certificate.certificate)
         return False
 
 
-class TLSCertificatesRequiresV2(Object):
+class TLSCertificatesRequiresV3(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
     on = CertificatesRequirerCharmEvents()  # type: ignore[reportAssignmentType]
@@ -1489,17 +1557,21 @@ class TLSCertificatesRequiresV2(Object):
         self,
         charm: CharmBase,
         relationship_name: str,
-        expiry_notification_time: int = 168,
+        expiry_notification_time: Optional[int] = None,
     ):
         """Generate/use private key and observes relation changed event.
 
         Args:
             charm: Charm object
             relationship_name: Juju relation name
-            expiry_notification_time (int): Time difference between now and expiry (in hours).
-                Used to trigger the CertificateExpiring event. Default: 7 days.
+            expiry_notification_time (int): Number of hours prior to certificate expiry.
+                Used to trigger the CertificateExpiring event.
+                This value is used as a recommendation only,
+                The actual value is calculated taking into account the provider's recommendation.
         """
         super().__init__(charm, relationship_name)
+        if not JujuVersion.from_environ().has_secrets:
+            logger.warning("This version of the TLS library requires Juju secrets (Juju >= 3.0)")
         self.relationship_name = relationship_name
         self.charm = charm
         self.expiry_notification_time = expiry_notification_time
@@ -1509,32 +1581,39 @@ class TLSCertificatesRequiresV2(Object):
         self.framework.observe(
             charm.on[relationship_name].relation_broken, self._on_relation_broken
         )
-        if JujuVersion.from_environ().has_secrets:
-            self.framework.observe(charm.on.secret_expired, self._on_secret_expired)
-        else:
-            self.framework.observe(charm.on.update_status, self._on_update_status)
+        self.framework.observe(charm.on.secret_expired, self._on_secret_expired)
 
-    @property
-    def _requirer_csrs(self) -> List[Dict[str, Union[bool, str]]]:
+    def get_requirer_csrs(self) -> List[RequirerCSR]:
         """Return list of requirer's CSRs from relation unit data.
 
-        Example:
-            [
-                {
-                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
-                    "ca": false
-                }
-            ]
+        Returns:
+            list: List of RequirerCSR objects.
         """
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
-            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+            return []
+        requirer_csrs = []
         requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
-        return requirer_relation_data.get("certificate_signing_requests", [])
+        requirer_csrs_dict = requirer_relation_data.get("certificate_signing_requests", [])
+        for requirer_csr_dict in requirer_csrs_dict:
+            csr = requirer_csr_dict.get("certificate_signing_request")
+            if not csr:
+                logger.warning("No CSR found in relation data - Skipping")
+                continue
+            ca = requirer_csr_dict.get("ca", False)
+            relation_csr = RequirerCSR(
+                relation_id=relation.id,
+                application_name=self.model.app.name,
+                unit_name=self.model.unit.name,
+                csr=csr,
+                is_ca=ca,
+            )
+            requirer_csrs.append(relation_csr)
+        return requirer_csrs
 
-    @property
-    def _provider_certificates(self) -> List[Dict[str, str]]:
+    def get_provider_certificates(self) -> List[ProviderCertificate]:
         """Return list of certificates from the provider's relation data."""
+        provider_certificates: List[ProviderCertificate] = []
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             logger.debug("No relation: %s", self.relationship_name)
@@ -1543,12 +1622,50 @@ class TLSCertificatesRequiresV2(Object):
             logger.debug("No remote app in relation: %s", self.relationship_name)
             return []
         provider_relation_data = _load_relation_data(relation.data[relation.app])
-        if not self._relation_data_is_valid(provider_relation_data):
-            logger.warning("Provider relation data did not pass JSON Schema validation")
-            return []
-        return provider_relation_data.get("certificates", [])
+        provider_certificate_dicts = provider_relation_data.get("certificates", [])
+        for provider_certificate_dict in provider_certificate_dicts:
+            certificate = provider_certificate_dict.get("certificate")
+            if not certificate:
+                logger.warning("No certificate found in relation data - Skipping")
+                continue
+            try:
+                certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
+            except ValueError as e:
+                logger.error("Could not load certificate - Skipping: %s", e)
+                continue
+            ca = provider_certificate_dict.get("ca")
+            chain = provider_certificate_dict.get("chain", [])
+            csr = provider_certificate_dict.get("certificate_signing_request")
+            recommended_expiry_notification_time = provider_certificate_dict.get(
+                "recommended_expiry_notification_time"
+            )
+            expiry_time = certificate_object.not_valid_after_utc
+            validity_start_time = certificate_object.not_valid_before_utc
+            expiry_notification_time = calculate_expiry_notification_time(
+                validity_start_time=validity_start_time,
+                expiry_time=expiry_time,
+                provider_recommended_notification_time=recommended_expiry_notification_time,
+                requirer_recommended_notification_time=self.expiry_notification_time,
+            )
+            if not csr:
+                logger.warning("No CSR found in relation data - Skipping")
+                continue
+            revoked = provider_certificate_dict.get("revoked", False)
+            provider_certificate = ProviderCertificate(
+                relation_id=relation.id,
+                application_name=relation.app.name,
+                csr=csr,
+                certificate=certificate,
+                ca=ca,
+                chain=chain,
+                revoked=revoked,
+                expiry_time=expiry_time,
+                expiry_notification_time=expiry_notification_time,
+            )
+            provider_certificates.append(provider_certificate)
+        return provider_certificates
 
-    def _add_requirer_csr(self, csr: str, is_ca: bool) -> None:
+    def _add_requirer_csr_to_relation_data(self, csr: str, is_ca: bool) -> None:
         """Add CSR to relation data.
 
         Args:
@@ -1564,18 +1681,23 @@ class TLSCertificatesRequiresV2(Object):
                 f"Relation {self.relationship_name} does not exist - "
                 f"The certificate request can't be completed"
             )
-        new_csr_dict: Dict[str, Union[bool, str]] = {
+        for requirer_csr in self.get_requirer_csrs():
+            if requirer_csr.csr == csr and requirer_csr.is_ca == is_ca:
+                logger.info("CSR already in relation data - Doing nothing")
+                return
+        new_csr_dict = {
             "certificate_signing_request": csr,
             "ca": is_ca,
         }
-        if new_csr_dict in self._requirer_csrs:
-            logger.info("CSR already in relation data - Doing nothing")
-            return
-        requirer_csrs = copy.deepcopy(self._requirer_csrs)
-        requirer_csrs.append(new_csr_dict)
-        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
+        requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
+        existing_relation_data = requirer_relation_data.get("certificate_signing_requests", [])
+        new_relation_data = copy.deepcopy(existing_relation_data)
+        new_relation_data.append(new_csr_dict)
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(
+            new_relation_data
+        )
 
-    def _remove_requirer_csr(self, csr: str) -> None:
+    def _remove_requirer_csr_from_relation_data(self, csr: str) -> None:
         """Remove CSR from relation data.
 
         Args:
@@ -1590,14 +1712,18 @@ class TLSCertificatesRequiresV2(Object):
                 f"Relation {self.relationship_name} does not exist - "
                 f"The certificate request can't be completed"
             )
-        requirer_csrs = copy.deepcopy(self._requirer_csrs)
-        if not requirer_csrs:
+        if not self.get_requirer_csrs():
             logger.info("No CSRs in relation data - Doing nothing")
             return
-        for requirer_csr in requirer_csrs:
+        requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
+        existing_relation_data = requirer_relation_data.get("certificate_signing_requests", [])
+        new_relation_data = copy.deepcopy(existing_relation_data)
+        for requirer_csr in new_relation_data:
             if requirer_csr["certificate_signing_request"] == csr:
-                requirer_csrs.remove(requirer_csr)
-        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
+                new_relation_data.remove(requirer_csr)
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(
+            new_relation_data
+        )
 
     def request_certificate_creation(
         self, certificate_signing_request: bytes, is_ca: bool = False
@@ -1617,7 +1743,9 @@ class TLSCertificatesRequiresV2(Object):
                 f"Relation {self.relationship_name} does not exist - "
                 f"The certificate request can't be completed"
             )
-        self._add_requirer_csr(certificate_signing_request.decode().strip(), is_ca=is_ca)
+        self._add_requirer_csr_to_relation_data(
+            certificate_signing_request.decode().strip(), is_ca=is_ca
+        )
         logger.info("Certificate request sent to provider")
 
     def request_certificate_revocation(self, certificate_signing_request: bytes) -> None:
@@ -1633,7 +1761,7 @@ class TLSCertificatesRequiresV2(Object):
         Returns:
             None
         """
-        self._remove_requirer_csr(certificate_signing_request.decode().strip())
+        self._remove_requirer_csr_from_relation_data(certificate_signing_request.decode().strip())
         logger.info("Certificate revocation sent to provider")
 
     def request_certificate_renewal(
@@ -1661,107 +1789,58 @@ class TLSCertificatesRequiresV2(Object):
         )
         logger.info("Certificate renewal request completed.")
 
-    def get_assigned_certificates(self) -> List[Dict[str, str]]:
+    def get_assigned_certificates(self) -> List[ProviderCertificate]:
         """Get a list of certificates that were assigned to this unit.
 
         Returns:
-            List of certificates. For example:
-            [
-                {
-                    "ca": "-----BEGIN CERTIFICATE-----...",
-                    "chain": [
-                        "-----BEGIN CERTIFICATE-----..."
-                    ],
-                    "certificate": "-----BEGIN CERTIFICATE-----...",
-                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
-                }
-            ]
+            List: List[ProviderCertificate]
         """
-        final_list = []
-        for csr in self.get_certificate_signing_requests(fulfilled_only=True):
-            assert isinstance(csr["certificate_signing_request"], str)
-            if cert := self._find_certificate_in_relation_data(csr["certificate_signing_request"]):
-                final_list.append(cert)
-        return final_list
+        assigned_certificates = []
+        for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            if cert := self._find_certificate_in_relation_data(requirer_csr.csr):
+                assigned_certificates.append(cert)
+        return assigned_certificates
 
-    def get_expiring_certificates(self) -> List[Dict[str, str]]:
+    def get_expiring_certificates(self) -> List[ProviderCertificate]:
         """Get a list of certificates that were assigned to this unit that are expiring or expired.
 
         Returns:
-            List of certificates. For example:
-            [
-                {
-                    "ca": "-----BEGIN CERTIFICATE-----...",
-                    "chain": [
-                        "-----BEGIN CERTIFICATE-----..."
-                    ],
-                    "certificate": "-----BEGIN CERTIFICATE-----...",
-                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
-                }
-            ]
+            List: List[ProviderCertificate]
         """
-        final_list = []
-        for csr in self.get_certificate_signing_requests(fulfilled_only=True):
-            assert isinstance(csr["certificate_signing_request"], str)
-            if cert := self._find_certificate_in_relation_data(csr["certificate_signing_request"]):
-                expiry_time = _get_certificate_expiry_time(cert["certificate"])
-                if not expiry_time:
+        expiring_certificates: List[ProviderCertificate] = []
+        for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            if cert := self._find_certificate_in_relation_data(requirer_csr.csr):
+                if not cert.expiry_time or not cert.expiry_notification_time:
                     continue
-                expiry_notification_time = expiry_time - timedelta(
-                    hours=self.expiry_notification_time
-                )
-                if datetime.now(timezone.utc) > expiry_notification_time:
-                    final_list.append(cert)
-        return final_list
+                if datetime.now(timezone.utc) > cert.expiry_notification_time:
+                    expiring_certificates.append(cert)
+        return expiring_certificates
 
     def get_certificate_signing_requests(
         self,
         fulfilled_only: bool = False,
         unfulfilled_only: bool = False,
-    ) -> List[Dict[str, Union[bool, str]]]:
+    ) -> List[RequirerCSR]:
         """Get the list of CSR's that were sent to the provider.
 
         You can choose to get only the CSR's that have a certificate assigned or only the CSR's
-          that don't.
+        that don't.
 
         Args:
             fulfilled_only (bool): This option will discard CSRs that don't have certificates yet.
             unfulfilled_only (bool): This option will discard CSRs that have certificates signed.
 
         Returns:
-            List of CSR dictionaries. For example:
-            [
-                {
-                    "certificate_signing_request": "-----BEGIN CERTIFICATE REQUEST-----...",
-                    "ca": false
-                }
-            ]
+            List of RequirerCSR objects.
         """
-        final_list = []
-        for csr in self._requirer_csrs:
-            assert isinstance(csr["certificate_signing_request"], str)
-            cert = self._find_certificate_in_relation_data(csr["certificate_signing_request"])
+        csrs = []
+        for requirer_csr in self.get_requirer_csrs():
+            cert = self._find_certificate_in_relation_data(requirer_csr.csr)
             if (unfulfilled_only and cert) or (fulfilled_only and not cert):
                 continue
-            final_list.append(csr)
+            csrs.append(requirer_csr)
 
-        return final_list
-
-    @staticmethod
-    def _relation_data_is_valid(certificates_data: dict) -> bool:
-        """Check whether relation data is valid based on json schema.
-
-        Args:
-            certificates_data: Certificate data in dict format.
-
-        Returns:
-            bool: Whether relation data is valid.
-        """
-        try:
-            validate(instance=certificates_data, schema=PROVIDER_JSON_SCHEMA)
-            return True
-        except exceptions.ValidationError:
-            return False
+        return csrs
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         """Handle relation changed event.
@@ -1771,9 +1850,8 @@ class TLSCertificatesRequiresV2(Object):
         If the provider certificate is revoked, emit a CertificateInvalidateEvent,
         otherwise emit a CertificateAvailableEvent.
 
-        When Juju secrets are available, remove the secret for revoked certificate,
-        or add a secret with the correct expiry time for new certificates.
-
+        Remove the secret for revoked certificate, or add a secret with the correct expiry
+        time for new certificates.
 
         Args:
             event: Juju event
@@ -1781,54 +1859,52 @@ class TLSCertificatesRequiresV2(Object):
         Returns:
             None
         """
+        if not event.app:
+            logger.warning("No remote app in relation - Skipping")
+            return
+        if not _relation_data_is_valid(event.relation, event.app, PROVIDER_JSON_SCHEMA):
+            logger.debug("Relation data did not pass JSON Schema validation")
+            return
+        provider_certificates = self.get_provider_certificates()
         requirer_csrs = [
-            certificate_creation_request["certificate_signing_request"]
-            for certificate_creation_request in self._requirer_csrs
+            certificate_creation_request.csr
+            for certificate_creation_request in self.get_requirer_csrs()
         ]
-        for certificate in self._provider_certificates:
-            if certificate["certificate_signing_request"] in requirer_csrs:
-                if certificate.get("revoked", False):
-                    if JujuVersion.from_environ().has_secrets:
-                        with suppress(SecretNotFoundError):
-                            secret = self.model.get_secret(
-                                label=f"{LIBID}-{certificate['certificate_signing_request']}"
-                            )
-                            secret.remove_all_revisions()
+        for certificate in provider_certificates:
+            if certificate.csr in requirer_csrs:
+                if certificate.revoked:
+                    with suppress(SecretNotFoundError):
+                        secret = self.model.get_secret(label=f"{LIBID}-{certificate.csr}")
+                        secret.remove_all_revisions()
                     self.on.certificate_invalidated.emit(
                         reason="revoked",
-                        certificate=certificate["certificate"],
-                        certificate_signing_request=certificate["certificate_signing_request"],
-                        ca=certificate["ca"],
-                        chain=certificate["chain"],
+                        certificate=certificate.certificate,
+                        certificate_signing_request=certificate.csr,
+                        ca=certificate.ca,
+                        chain=certificate.chain,
                     )
                 else:
-                    if JujuVersion.from_environ().has_secrets:
-                        try:
-                            secret = self.model.get_secret(
-                                label=f"{LIBID}-{certificate['certificate_signing_request']}"
-                            )
-                            secret.set_content({"certificate": certificate["certificate"]})
-                            secret.set_info(
-                                expire=self._get_next_secret_expiry_time(
-                                    certificate["certificate"]
-                                ),
-                            )
-                        except SecretNotFoundError:
-                            secret = self.charm.unit.add_secret(
-                                {"certificate": certificate["certificate"]},
-                                label=f"{LIBID}-{certificate['certificate_signing_request']}",
-                                expire=self._get_next_secret_expiry_time(
-                                    certificate["certificate"]
-                                ),
-                            )
+                    try:
+                        secret = self.model.get_secret(label=f"{LIBID}-{certificate.csr}")
+                        secret.set_content({"certificate": certificate.certificate})
+                        secret.set_info(
+                            expire=self._get_next_secret_expiry_time(certificate),
+                        )
+                    except SecretNotFoundError:
+                        logger.debug("Adding secret with label %s", f"{LIBID}-{certificate.csr}")
+                        secret = self.charm.unit.add_secret(
+                            {"certificate": certificate.certificate},
+                            label=f"{LIBID}-{certificate.csr}",
+                            expire=self._get_next_secret_expiry_time(certificate),
+                        )
                     self.on.certificate_available.emit(
-                        certificate_signing_request=certificate["certificate_signing_request"],
-                        certificate=certificate["certificate"],
-                        ca=certificate["ca"],
-                        chain=certificate["chain"],
+                        certificate_signing_request=certificate.csr,
+                        certificate=certificate.certificate,
+                        ca=certificate.ca,
+                        chain=certificate.chain,
                     )
 
-    def _get_next_secret_expiry_time(self, certificate: str) -> Optional[datetime]:
+    def _get_next_secret_expiry_time(self, certificate: ProviderCertificate) -> Optional[datetime]:
         """Return the expiry time or expiry notification time.
 
         Extracts the expiry time from the provided certificate, calculates the
@@ -1836,20 +1912,21 @@ class TLSCertificatesRequiresV2(Object):
         the future.
 
         Args:
-            certificate: x509 certificate
+            certificate: ProviderCertificate object
 
         Returns:
             Optional[datetime]: None if the certificate expiry time cannot be read,
                                 next expiry time otherwise.
         """
-        expiry_time = _get_certificate_expiry_time(certificate)
-        if not expiry_time:
+        if not certificate.expiry_time or not certificate.expiry_notification_time:
             return None
-        expiry_notification_time = expiry_time - timedelta(hours=self.expiry_notification_time)
-        return _get_closest_future_time(expiry_notification_time, expiry_time)
+        return _get_closest_future_time(
+            certificate.expiry_notification_time,
+            certificate.expiry_time,
+        )
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Handle relation broken event.
+        """Handle Relation Broken Event.
 
         Emitting `all_certificates_invalidated` from `relation-broken` rather
         than `relation-departed` since certs are stored in app data.
@@ -1863,7 +1940,7 @@ class TLSCertificatesRequiresV2(Object):
         self.on.all_certificates_invalidated.emit()
 
     def _on_secret_expired(self, event: SecretExpiredEvent) -> None:
-        """Handle secret expired event.
+        """Handle Secret Expired Event.
 
         Loads the certificate from the secret, and will emit 1 of 2
         events.
@@ -1881,79 +1958,42 @@ class TLSCertificatesRequiresV2(Object):
         if not event.secret.label or not event.secret.label.startswith(f"{LIBID}-"):
             return
         csr = event.secret.label[len(f"{LIBID}-") :]
-        certificate_dict = self._find_certificate_in_relation_data(csr)
-        if not certificate_dict:
+        provider_certificate = self._find_certificate_in_relation_data(csr)
+        if not provider_certificate:
             # A secret expired but we did not find matching certificate. Cleaning up
             event.secret.remove_all_revisions()
             return
 
-        expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
-        if not expiry_time:
+        if not provider_certificate.expiry_time:
             # A secret expired but matching certificate is invalid. Cleaning up
             event.secret.remove_all_revisions()
             return
 
-        if datetime.now(timezone.utc) < expiry_time:
+        if datetime.now(timezone.utc) < provider_certificate.expiry_time:
             logger.warning("Certificate almost expired")
             self.on.certificate_expiring.emit(
-                certificate=certificate_dict["certificate"],
-                expiry=expiry_time.isoformat(),
+                certificate=provider_certificate.certificate,
+                expiry=provider_certificate.expiry_time.isoformat(),
             )
             event.secret.set_info(
-                expire=_get_certificate_expiry_time(certificate_dict["certificate"]),
+                expire=provider_certificate.expiry_time,
             )
         else:
             logger.warning("Certificate is expired")
             self.on.certificate_invalidated.emit(
                 reason="expired",
-                certificate=certificate_dict["certificate"],
-                certificate_signing_request=certificate_dict["certificate_signing_request"],
-                ca=certificate_dict["ca"],
-                chain=certificate_dict["chain"],
+                certificate=provider_certificate.certificate,
+                certificate_signing_request=provider_certificate.csr,
+                ca=provider_certificate.ca,
+                chain=provider_certificate.chain,
             )
-            self.request_certificate_revocation(certificate_dict["certificate"].encode())
+            self.request_certificate_revocation(provider_certificate.certificate.encode())
             event.secret.remove_all_revisions()
 
-    def _find_certificate_in_relation_data(self, csr: str) -> Optional[Dict[str, Any]]:
+    def _find_certificate_in_relation_data(self, csr: str) -> Optional[ProviderCertificate]:
         """Return the certificate that match the given CSR."""
-        for certificate_dict in self._provider_certificates:
-            if certificate_dict["certificate_signing_request"] != csr:
+        for provider_certificate in self.get_provider_certificates():
+            if provider_certificate.csr != csr:
                 continue
-            return certificate_dict
+            return provider_certificate
         return None
-
-    def _on_update_status(self, event: UpdateStatusEvent) -> None:
-        """Handle update status event.
-
-        Goes through each certificate in the "certificates" relation and checks their expiry date.
-        If they are close to expire (<7 days), emits a CertificateExpiringEvent event and if
-        they are expired, emits a CertificateExpiredEvent.
-
-        Args:
-            event (UpdateStatusEvent): Juju event
-
-        Returns:
-            None
-        """
-        for certificate_dict in self._provider_certificates:
-            expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
-            if not expiry_time:
-                continue
-            time_difference = expiry_time - datetime.now(timezone.utc)
-            if time_difference.total_seconds() < 0:
-                logger.warning("Certificate is expired")
-                self.on.certificate_invalidated.emit(
-                    reason="expired",
-                    certificate=certificate_dict["certificate"],
-                    certificate_signing_request=certificate_dict["certificate_signing_request"],
-                    ca=certificate_dict["ca"],
-                    chain=certificate_dict["chain"],
-                )
-                self.request_certificate_revocation(certificate_dict["certificate"].encode())
-                continue
-            if time_difference.total_seconds() < (self.expiry_notification_time * 60 * 60):
-                logger.warning("Certificate almost expired")
-                self.on.certificate_expiring.emit(
-                    certificate=certificate_dict["certificate"],
-                    expiry=expiry_time.isoformat(),
-                )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 kubernetes==24.2.0 # last version with DiscoveryV1beta1Api
-ops==2.12
-jsonschema
-cryptography
+ops==2.12.0
+jsonschema==4.21.1
+cryptography==42.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 kubernetes==24.2.0 # last version with DiscoveryV1beta1Api
-ops==2.12.0
+ops==2.13.0
 jsonschema==4.21.1
 cryptography==42.0.5

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,12 +11,12 @@ from typing import Any, Dict, List, Optional, Union, cast
 
 import kubernetes.client
 from charms.nginx_ingress_integrator.v0.nginx_route import provide_nginx_route
-from charms.tls_certificates_interface.v2.tls_certificates import (
+from charms.tls_certificates_interface.v3.tls_certificates import (
     AllCertificatesInvalidatedEvent,
     CertificateAvailableEvent,
     CertificateExpiringEvent,
     CertificateInvalidatedEvent,
-    TLSCertificatesRequiresV2,
+    TLSCertificatesRequiresV3,
 )
 from charms.traefik_k8s.v2.ingress import IngressPerAppProvider
 from ops.charm import ActionEvent, CharmBase, EventBase, RelationCreatedEvent, RelationJoinedEvent
@@ -66,7 +66,7 @@ class NginxIngressCharm(CharmBase):
 
         self.framework.observe(self._ingress_provider.on.data_provided, self._on_data_provided)
         self.framework.observe(self._ingress_provider.on.data_removed, self._on_data_removed)
-        self.certificates = TLSCertificatesRequiresV2(self, TLS_CERT)
+        self.certificates = TLSCertificatesRequiresV3(self, TLS_CERT)
         self.framework.observe(
             self.on.certificates_relation_created, self._on_certificates_relation_created
         )
@@ -528,8 +528,8 @@ class NginxIngressCharm(CharmBase):
             event.defer()
             return
         if event.reason == "revoked":
-            hostname = self._tls.get_hostname_from_csr(
-                tls_certificates_relation, event.certificate_signing_request
+            hostname = self._tls.get_hostname_from_cert(
+                tls_certificates_relation, event.certificate
             )
             self._certificate_revoked([hostname])
         if event.reason == "expired":

--- a/src/charm.py
+++ b/src/charm.py
@@ -528,9 +528,7 @@ class NginxIngressCharm(CharmBase):
             event.defer()
             return
         if event.reason == "revoked":
-            hostname = self._tls.get_hostname_from_cert(
-                tls_certificates_relation, event.certificate
-            )
+            hostname = self._tls.get_hostname_from_cert(event.certificate)
             self._certificate_revoked([hostname])
         if event.reason == "expired":
             self._tls.certificate_expiring(event, self.certificates)

--- a/src/ingress_definition.py
+++ b/src/ingress_definition.py
@@ -511,7 +511,7 @@ class IngressDefinitionEssence:  # pylint: disable=too-many-public-methods
     @property
     def ingress_class(self) -> Optional[str]:
         """Return the ingress class configured in the charm."""
-        return self.config["ingress-class"]
+        return str(self.config["ingress-class"]) if self.config["ingress-class"] else None
 
 
 @dataclasses.dataclass

--- a/src/tls_relation.py
+++ b/src/tls_relation.py
@@ -114,8 +114,14 @@ class TLSRelationService:
 
         Returns:
             The value from the field.
+
+        Raises:
+            KeyError: if the field is not found in the relation databag.
         """
         field_value = tls_relation.data[self.charm_app].get(relation_field)
+        if not field_value:
+            raise KeyError(f"{relation_field} field not found in {tls_relation.name}")
+
         return field_value
 
     def get_hostname_from_cert(self, certificate: str) -> str:

--- a/tests/integration/provider_charm/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/tests/integration/provider_charm/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 
@@ -7,16 +7,19 @@
 This library contains the Requires and Provides classes for handling the tls-certificates
 interface.
 
+Pre-requisites:
+  - Juju >= 3.0
+
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.tls_certificates_interface.v2.tls_certificates
+charmcraft fetch-lib charms.tls_certificates_interface.v3.tls_certificates
 ```
 
 Add the following libraries to the charm's `requirements.txt` file:
 - jsonschema
-- cryptography
+- cryptography >= 42.0.0
 
 Add the following section to the charm's `charmcraft.yaml` file:
 ```yaml
@@ -36,10 +39,10 @@ this example, the provider charm is storing its private key using a peer relatio
 
 Example:
 ```python
-from charms.tls_certificates_interface.v2.tls_certificates import (
+from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateCreationRequestEvent,
     CertificateRevocationRequestEvent,
-    TLSCertificatesProvidesV2,
+    TLSCertificatesProvidesV3,
     generate_private_key,
 )
 from ops.charm import CharmBase, InstallEvent
@@ -59,7 +62,7 @@ class ExampleProviderCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.certificates = TLSCertificatesProvidesV2(self, "certificates")
+        self.certificates = TLSCertificatesProvidesV3(self, "certificates")
         self.framework.observe(
             self.certificates.on.certificate_request,
             self._on_certificate_request
@@ -108,6 +111,7 @@ class ExampleProviderCharm(CharmBase):
             ca=ca_certificate,
             chain=[ca_certificate, certificate],
             relation_id=event.relation_id,
+            recommended_expiry_notification_time=720,
         )
 
     def _on_certificate_revocation_request(self, event: CertificateRevocationRequestEvent) -> None:
@@ -126,15 +130,15 @@ this example, the requirer charm is storing its certificates using a peer relati
 
 Example:
 ```python
-from charms.tls_certificates_interface.v2.tls_certificates import (
+from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateAvailableEvent,
     CertificateExpiringEvent,
     CertificateRevokedEvent,
-    TLSCertificatesRequiresV2,
+    TLSCertificatesRequiresV3,
     generate_csr,
     generate_private_key,
 )
-from ops.charm import CharmBase, RelationJoinedEvent
+from ops.charm import CharmBase, RelationCreatedEvent
 from ops.main import main
 from ops.model import ActiveStatus, WaitingStatus
 from typing import Union
@@ -145,10 +149,10 @@ class ExampleRequirerCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self.cert_subject = "whatever"
-        self.certificates = TLSCertificatesRequiresV2(self, "certificates")
+        self.certificates = TLSCertificatesRequiresV3(self, "certificates")
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(
-            self.on.certificates_relation_joined, self._on_certificates_relation_joined
+            self.on.certificates_relation_created, self._on_certificates_relation_created
         )
         self.framework.observe(
             self.certificates.on.certificate_available, self._on_certificate_available
@@ -176,7 +180,7 @@ class ExampleRequirerCharm(CharmBase):
             {"private_key_password": "banana", "private_key": private_key.decode()}
         )
 
-    def _on_certificates_relation_joined(self, event: RelationJoinedEvent) -> None:
+    def _on_certificates_relation_created(self, event: RelationCreatedEvent) -> None:
         replicas_relation = self.model.get_relation("replicas")
         if not replicas_relation:
             self.unit.status = WaitingStatus("Waiting for peer relation to be created")
@@ -277,44 +281,49 @@ import json
 import logging
 import uuid
 from contextlib import suppress
-from datetime import datetime, timedelta
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from ipaddress import IPv4Address
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from cryptography import x509
 from cryptography.hazmat._oid import ExtensionOID
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from cryptography.hazmat.primitives.serialization import pkcs12
-from cryptography.x509.extensions import Extension, ExtensionNotFound
-from jsonschema import exceptions, validate  # type: ignore[import]
+from jsonschema import exceptions, validate
 from ops.charm import (
     CharmBase,
     CharmEvents,
     RelationBrokenEvent,
     RelationChangedEvent,
     SecretExpiredEvent,
-    UpdateStatusEvent,
 )
 from ops.framework import EventBase, EventSource, Handle, Object
 from ops.jujuversion import JujuVersion
-from ops.model import Relation, SecretNotFoundError
+from ops.model import (
+    Application,
+    ModelError,
+    Relation,
+    RelationDataContent,
+    SecretNotFoundError,
+    Unit,
+)
 
 # The unique Charmhub library identifier, never change it
 LIBID = "afd8c2bccf834997afce12c2706d2ede"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 2
+LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 13
 
 PYDEPS = ["cryptography", "jsonschema"]
 
 REQUIRER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v2/schemas/requirer.json",  # noqa: E501
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/tls_certificates/v1/schemas/requirer.json",
     "type": "object",
     "title": "`tls_certificates` requirer root schema",
     "description": "The `tls_certificates` root schema comprises the entire requirer databag for this interface.",  # noqa: E501
@@ -335,7 +344,10 @@ REQUIRER_JSON_SCHEMA = {
             "type": "array",
             "items": {
                 "type": "object",
-                "properties": {"certificate_signing_request": {"type": "string"}},
+                "properties": {
+                    "certificate_signing_request": {"type": "string"},
+                    "ca": {"type": "boolean"},
+                },
                 "required": ["certificate_signing_request"],
             },
         }
@@ -346,7 +358,7 @@ REQUIRER_JSON_SCHEMA = {
 
 PROVIDER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "$id": "https://canonical.github.io/charm-relation-interfaces/tls_certificates/v2/schemas/provider.json",  # noqa: E501
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/tls_certificates/v1/schemas/provider.json",
     "type": "object",
     "title": "`tls_certificates` provider root schema",
     "description": "The `tls_certificates` root schema comprises the entire provider databag for this interface.",  # noqa: E501
@@ -420,6 +432,60 @@ PROVIDER_JSON_SCHEMA = {
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class RequirerCSR:
+    """This class represents a certificate signing request from an interface Requirer."""
+
+    relation_id: int
+    application_name: str
+    unit_name: str
+    csr: str
+    is_ca: bool
+
+
+@dataclass
+class ProviderCertificate:
+    """This class represents a certificate from an interface Provider."""
+
+    relation_id: int
+    application_name: str
+    csr: str
+    certificate: str
+    ca: str
+    chain: List[str]
+    revoked: bool
+    expiry_time: datetime
+    expiry_notification_time: Optional[datetime] = None
+
+    def chain_as_pem(self) -> str:
+        """Return full certificate chain as a PEM string."""
+        return "\n\n".join(reversed(self.chain))
+
+    def to_json(self) -> str:
+        """Return the object as a JSON string.
+
+        Returns:
+            str: JSON representation of the object
+        """
+        return json.dumps(
+            {
+                "relation_id": self.relation_id,
+                "application_name": self.application_name,
+                "csr": self.csr,
+                "certificate": self.certificate,
+                "ca": self.ca,
+                "chain": self.chain,
+                "revoked": self.revoked,
+                "expiry_time": self.expiry_time.isoformat(),
+                "expiry_notification_time": (
+                    self.expiry_notification_time.isoformat()
+                    if self.expiry_notification_time
+                    else None
+                ),
+            }
+        )
+
+
 class CertificateAvailableEvent(EventBase):
     """Charm Event triggered when a TLS certificate is available."""
 
@@ -438,7 +504,7 @@ class CertificateAvailableEvent(EventBase):
         self.chain = chain
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "certificate": self.certificate,
             "certificate_signing_request": self.certificate_signing_request,
@@ -447,11 +513,15 @@ class CertificateAvailableEvent(EventBase):
         }
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.certificate = snapshot["certificate"]
         self.certificate_signing_request = snapshot["certificate_signing_request"]
         self.ca = snapshot["ca"]
         self.chain = snapshot["chain"]
+
+    def chain_as_pem(self) -> str:
+        """Return full certificate chain as a PEM string."""
+        return "\n\n".join(reversed(self.chain))
 
 
 class CertificateExpiringEvent(EventBase):
@@ -471,11 +541,11 @@ class CertificateExpiringEvent(EventBase):
         self.expiry = expiry
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {"certificate": self.certificate, "expiry": self.expiry}
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.certificate = snapshot["certificate"]
         self.expiry = snapshot["expiry"]
 
@@ -500,7 +570,7 @@ class CertificateInvalidatedEvent(EventBase):
         self.chain = chain
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "reason": self.reason,
             "certificate_signing_request": self.certificate_signing_request,
@@ -510,7 +580,7 @@ class CertificateInvalidatedEvent(EventBase):
         }
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.reason = snapshot["reason"]
         self.certificate_signing_request = snapshot["certificate_signing_request"]
         self.certificate = snapshot["certificate"]
@@ -525,33 +595,42 @@ class AllCertificatesInvalidatedEvent(EventBase):
         super().__init__(handle)
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {}
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         pass
 
 
 class CertificateCreationRequestEvent(EventBase):
     """Charm Event triggered when a TLS certificate is required."""
 
-    def __init__(self, handle: Handle, certificate_signing_request: str, relation_id: int):
+    def __init__(
+        self,
+        handle: Handle,
+        certificate_signing_request: str,
+        relation_id: int,
+        is_ca: bool = False,
+    ):
         super().__init__(handle)
         self.certificate_signing_request = certificate_signing_request
         self.relation_id = relation_id
+        self.is_ca = is_ca
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "certificate_signing_request": self.certificate_signing_request,
             "relation_id": self.relation_id,
+            "is_ca": self.is_ca,
         }
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.certificate_signing_request = snapshot["certificate_signing_request"]
         self.relation_id = snapshot["relation_id"]
+        self.is_ca = snapshot["is_ca"]
 
 
 class CertificateRevocationRequestEvent(EventBase):
@@ -572,7 +651,7 @@ class CertificateRevocationRequestEvent(EventBase):
         self.chain = chain
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "certificate": self.certificate,
             "certificate_signing_request": self.certificate_signing_request,
@@ -581,31 +660,98 @@ class CertificateRevocationRequestEvent(EventBase):
         }
 
     def restore(self, snapshot: dict):
-        """Restores snapshot."""
+        """Restore snapshot."""
         self.certificate = snapshot["certificate"]
         self.certificate_signing_request = snapshot["certificate_signing_request"]
         self.ca = snapshot["ca"]
         self.chain = snapshot["chain"]
 
 
-def _load_relation_data(raw_relation_data: dict) -> dict:
-    """Loads relation data from the relation data bag.
+def _load_relation_data(relation_data_content: RelationDataContent) -> dict:
+    """Load relation data from the relation data bag.
 
     Json loads all data.
 
     Args:
-        raw_relation_data: Relation data from the databag
+        relation_data_content: Relation data from the databag
 
     Returns:
         dict: Relation data in dict format.
     """
-    certificate_data = dict()
-    for key in raw_relation_data:
-        try:
-            certificate_data[key] = json.loads(raw_relation_data[key])
-        except (json.decoder.JSONDecodeError, TypeError):
-            certificate_data[key] = raw_relation_data[key]
+    certificate_data = {}
+    try:
+        for key in relation_data_content:
+            try:
+                certificate_data[key] = json.loads(relation_data_content[key])
+            except (json.decoder.JSONDecodeError, TypeError):
+                certificate_data[key] = relation_data_content[key]
+    except ModelError:
+        pass
     return certificate_data
+
+
+def _get_closest_future_time(
+    expiry_notification_time: datetime, expiry_time: datetime
+) -> datetime:
+    """Return expiry_notification_time if not in the past, otherwise return expiry_time.
+
+    Args:
+        expiry_notification_time (datetime): Notification time of impending expiration
+        expiry_time (datetime): Expiration time
+
+    Returns:
+        datetime: expiry_notification_time if not in the past, expiry_time otherwise
+    """
+    return (
+        expiry_notification_time
+        if datetime.now(timezone.utc) < expiry_notification_time
+        else expiry_time
+    )
+
+
+def calculate_expiry_notification_time(
+    validity_start_time: datetime,
+    expiry_time: datetime,
+    provider_recommended_notification_time: Optional[int],
+    requirer_recommended_notification_time: Optional[int],
+) -> datetime:
+    """Calculate a reasonable time to notify the user about the certificate expiry.
+
+    It takes into account the time recommended by the provider and by the requirer.
+    Time recommended by the provider is preferred,
+    then time recommended by the requirer,
+    then dynamically calculated time.
+
+    Args:
+        validity_start_time: Certificate validity time
+        expiry_time: Certificate expiry time
+        provider_recommended_notification_time:
+            Time in hours prior to expiry to notify the user.
+            Recommended by the provider.
+        requirer_recommended_notification_time:
+            Time in hours prior to expiry to notify the user.
+            Recommended by the requirer.
+
+    Returns:
+        datetime: Time to notify the user about the certificate expiry.
+    """
+    if provider_recommended_notification_time is not None:
+        provider_recommended_notification_time = abs(provider_recommended_notification_time)
+        provider_recommendation_time_delta = expiry_time - timedelta(
+            hours=provider_recommended_notification_time
+        )
+        if validity_start_time < provider_recommendation_time_delta:
+            return provider_recommendation_time_delta
+
+    if requirer_recommended_notification_time is not None:
+        requirer_recommended_notification_time = abs(requirer_recommended_notification_time)
+        requirer_recommendation_time_delta = expiry_time - timedelta(
+            hours=requirer_recommended_notification_time
+        )
+        if validity_start_time < requirer_recommendation_time_delta:
+            return requirer_recommendation_time_delta
+    calculated_hours = (expiry_time - validity_start_time).total_seconds() / (3600 * 3)
+    return expiry_time - timedelta(hours=calculated_hours)
 
 
 def generate_ca(
@@ -615,11 +761,11 @@ def generate_ca(
     validity: int = 365,
     country: str = "US",
 ) -> bytes:
-    """Generates a CA Certificate.
+    """Generate a CA Certificate.
 
     Args:
         private_key (bytes): Private key
-        subject (str): Certificate subject
+        subject (str): Common Name that can be an IP or a Full Qualified Domain Name (FQDN).
         private_key_password (bytes): Private key password
         validity (int): Certificate validity time (in days)
         country (str): Certificate Issuing country
@@ -630,7 +776,7 @@ def generate_ca(
     private_key_object = serialization.load_pem_private_key(
         private_key, password=private_key_password
     )
-    subject = issuer = x509.Name(
+    subject_name = x509.Name(
         [
             x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country),
             x509.NameAttribute(x509.NameOID.COMMON_NAME, subject),
@@ -653,12 +799,12 @@ def generate_ca(
     )
     cert = (
         x509.CertificateBuilder()
-        .subject_name(subject)
-        .issuer_name(issuer)
+        .subject_name(subject_name)
+        .issuer_name(subject_name)
         .public_key(private_key_object.public_key())  # type: ignore[arg-type]
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
         .add_extension(x509.SubjectKeyIdentifier(digest=subject_identifier), critical=False)
         .add_extension(
             x509.AuthorityKeyIdentifier(
@@ -678,6 +824,105 @@ def generate_ca(
     return cert.public_bytes(serialization.Encoding.PEM)
 
 
+def get_certificate_extensions(
+    authority_key_identifier: bytes,
+    csr: x509.CertificateSigningRequest,
+    alt_names: Optional[List[str]],
+    is_ca: bool,
+) -> List[x509.Extension]:
+    """Generate a list of certificate extensions from a CSR and other known information.
+
+    Args:
+        authority_key_identifier (bytes): Authority key identifier
+        csr (x509.CertificateSigningRequest): CSR
+        alt_names (list): List of alt names to put on cert - prefer putting SANs in CSR
+        is_ca (bool): Whether the certificate is a CA certificate
+
+    Returns:
+        List[x509.Extension]: List of extensions
+    """
+    cert_extensions_list: List[x509.Extension] = [
+        x509.Extension(
+            oid=ExtensionOID.AUTHORITY_KEY_IDENTIFIER,
+            value=x509.AuthorityKeyIdentifier(
+                key_identifier=authority_key_identifier,
+                authority_cert_issuer=None,
+                authority_cert_serial_number=None,
+            ),
+            critical=False,
+        ),
+        x509.Extension(
+            oid=ExtensionOID.SUBJECT_KEY_IDENTIFIER,
+            value=x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
+            critical=False,
+        ),
+        x509.Extension(
+            oid=ExtensionOID.BASIC_CONSTRAINTS,
+            critical=True,
+            value=x509.BasicConstraints(ca=is_ca, path_length=None),
+        ),
+    ]
+
+    sans: List[x509.GeneralName] = []
+    san_alt_names = [x509.DNSName(name) for name in alt_names] if alt_names else []
+    sans.extend(san_alt_names)
+    try:
+        loaded_san_ext = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        sans.extend(
+            [x509.DNSName(name) for name in loaded_san_ext.value.get_values_for_type(x509.DNSName)]
+        )
+        sans.extend(
+            [x509.IPAddress(ip) for ip in loaded_san_ext.value.get_values_for_type(x509.IPAddress)]
+        )
+        sans.extend(
+            [
+                x509.RegisteredID(oid)
+                for oid in loaded_san_ext.value.get_values_for_type(x509.RegisteredID)
+            ]
+        )
+    except x509.ExtensionNotFound:
+        pass
+
+    if sans:
+        cert_extensions_list.append(
+            x509.Extension(
+                oid=ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
+                critical=False,
+                value=x509.SubjectAlternativeName(sans),
+            )
+        )
+
+    if is_ca:
+        cert_extensions_list.append(
+            x509.Extension(
+                ExtensionOID.KEY_USAGE,
+                critical=True,
+                value=x509.KeyUsage(
+                    digital_signature=False,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+            )
+        )
+
+    existing_oids = {ext.oid for ext in cert_extensions_list}
+    for extension in csr.extensions:
+        if extension.oid == ExtensionOID.SUBJECT_ALTERNATIVE_NAME:
+            continue
+        if extension.oid in existing_oids:
+            logger.warning("Extension %s is managed by the TLS provider, ignoring.", extension.oid)
+            continue
+        cert_extensions_list.append(extension)
+
+    return cert_extensions_list
+
+
 def generate_certificate(
     csr: bytes,
     ca: bytes,
@@ -685,8 +930,9 @@ def generate_certificate(
     ca_key_password: Optional[bytes] = None,
     validity: int = 365,
     alt_names: Optional[List[str]] = None,
+    is_ca: bool = False,
 ) -> bytes:
-    """Generates a TLS certificate based on a CSR.
+    """Generate a TLS certificate based on a CSR.
 
     Args:
         csr (bytes): CSR
@@ -695,13 +941,15 @@ def generate_certificate(
         ca_key_password: CA private key password
         validity (int): Certificate validity (in days)
         alt_names (list): List of alt names to put on cert - prefer putting SANs in CSR
+        is_ca (bool): Whether the certificate is a CA certificate
 
     Returns:
         bytes: Certificate
     """
     csr_object = x509.load_pem_x509_csr(csr)
     subject = csr_object.subject
-    issuer = x509.load_pem_x509_certificate(ca).issuer
+    ca_pem = x509.load_pem_x509_certificate(ca)
+    issuer = ca_pem.issuer
     private_key = serialization.load_pem_private_key(ca_key, password=ca_key_password)
 
     certificate_builder = (
@@ -710,73 +958,28 @@ def generate_certificate(
         .issuer_name(issuer)
         .public_key(csr_object.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.utcnow())
-        .not_valid_after(datetime.utcnow() + timedelta(days=validity))
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=validity))
     )
-
-    extensions_list = csr_object.extensions
-    san_ext: Optional[x509.Extension] = None
-    if alt_names:
-        full_sans_dns = alt_names.copy()
+    extensions = get_certificate_extensions(
+        authority_key_identifier=ca_pem.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier
+        ).value.key_identifier,
+        csr=csr_object,
+        alt_names=alt_names,
+        is_ca=is_ca,
+    )
+    for extension in extensions:
         try:
-            loaded_san_ext = csr_object.extensions.get_extension_for_class(
-                x509.SubjectAlternativeName
+            certificate_builder = certificate_builder.add_extension(
+                extval=extension.value,
+                critical=extension.critical,
             )
-            full_sans_dns.extend(loaded_san_ext.value.get_values_for_type(x509.DNSName))
-        except ExtensionNotFound:
-            pass
-        finally:
-            san_ext = Extension(
-                ExtensionOID.SUBJECT_ALTERNATIVE_NAME,
-                False,
-                x509.SubjectAlternativeName([x509.DNSName(name) for name in full_sans_dns]),
-            )
-            if not extensions_list:
-                extensions_list = x509.Extensions([san_ext])
+        except ValueError as e:
+            logger.warning("Failed to add extension %s: %s", extension.oid, e)
 
-    for extension in extensions_list:
-        if extension.value.oid == ExtensionOID.SUBJECT_ALTERNATIVE_NAME and san_ext:
-            extension = san_ext
-
-        certificate_builder = certificate_builder.add_extension(
-            extension.value,
-            critical=extension.critical,
-        )
-    certificate_builder._version = x509.Version.v3
     cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
     return cert.public_bytes(serialization.Encoding.PEM)
-
-
-def generate_pfx_package(
-    certificate: bytes,
-    private_key: bytes,
-    package_password: str,
-    private_key_password: Optional[bytes] = None,
-) -> bytes:
-    """Generates a PFX package to contain the TLS certificate and private key.
-
-    Args:
-        certificate (bytes): TLS certificate
-        private_key (bytes): Private key
-        package_password (str): Password to open the PFX package
-        private_key_password (bytes): Private key password
-
-    Returns:
-        bytes:
-    """
-    private_key_object = serialization.load_pem_private_key(
-        private_key, password=private_key_password
-    )
-    certificate_object = x509.load_pem_x509_certificate(certificate)
-    name = certificate_object.subject.rfc4514_string()
-    pfx_bytes = pkcs12.serialize_key_and_certificates(
-        name=name.encode(),
-        cert=certificate_object,
-        key=private_key_object,  # type: ignore[arg-type]
-        cas=None,
-        encryption_algorithm=serialization.BestAvailableEncryption(package_password.encode()),
-    )
-    return pfx_bytes
 
 
 def generate_private_key(
@@ -784,7 +987,7 @@ def generate_private_key(
     key_size: int = 2048,
     public_exponent: int = 65537,
 ) -> bytes:
-    """Generates a private key.
+    """Generate a private key.
 
     Args:
         password (bytes): Password for decrypting the private key
@@ -810,13 +1013,15 @@ def generate_private_key(
     return key_bytes
 
 
-def generate_csr(
+def generate_csr(  # noqa: C901
     private_key: bytes,
     subject: str,
     add_unique_id_to_subject_name: bool = True,
     organization: Optional[str] = None,
     email_address: Optional[str] = None,
     country_name: Optional[str] = None,
+    state_or_province_name: Optional[str] = None,
+    locality_name: Optional[str] = None,
     private_key_password: Optional[bytes] = None,
     sans: Optional[List[str]] = None,
     sans_oid: Optional[List[str]] = None,
@@ -824,24 +1029,26 @@ def generate_csr(
     sans_dns: Optional[List[str]] = None,
     additional_critical_extensions: Optional[List] = None,
 ) -> bytes:
-    """Generates a CSR using private key and subject.
+    """Generate a CSR using private key and subject.
 
     Args:
         private_key (bytes): Private key
-        subject (str): CSR Subject.
+        subject (str): CSR Common Name that can be an IP or a Full Qualified Domain Name (FQDN).
         add_unique_id_to_subject_name (bool): Whether a unique ID must be added to the CSR's
             subject name. Always leave to "True" when the CSR is used to request certificates
             using the tls-certificates relation.
         organization (str): Name of organization.
         email_address (str): Email address.
         country_name (str): Country Name.
+        state_or_province_name (str): State or Province Name.
+        locality_name (str): Locality Name.
         private_key_password (bytes): Private key password
         sans (list): Use sans_dns - this will be deprecated in a future release
             List of DNS subject alternative names (keeping it for now for backward compatibility)
         sans_oid (list): List of registered ID SANs
         sans_dns (list): List of DNS subject alternative names (similar to the arg: sans)
         sans_ip (list): List of IP subject alternative names
-        additional_critical_extensions (list): List if critical additional extension objects.
+        additional_critical_extensions (list): List of critical additional extension objects.
             Object must be a x509 ExtensionType.
 
     Returns:
@@ -860,6 +1067,12 @@ def generate_csr(
         subject_name.append(x509.NameAttribute(x509.NameOID.EMAIL_ADDRESS, email_address))
     if country_name:
         subject_name.append(x509.NameAttribute(x509.NameOID.COUNTRY_NAME, country_name))
+    if state_or_province_name:
+        subject_name.append(
+            x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, state_or_province_name)
+        )
+    if locality_name:
+        subject_name.append(x509.NameAttribute(x509.NameOID.LOCALITY_NAME, locality_name))
     csr = x509.CertificateSigningRequestBuilder(subject_name=x509.Name(subject_name))
 
     _sans: List[x509.GeneralName] = []
@@ -882,6 +1095,59 @@ def generate_csr(
     return signed_certificate.public_bytes(serialization.Encoding.PEM)
 
 
+def csr_matches_certificate(csr: str, cert: str) -> bool:
+    """Check if a CSR matches a certificate.
+
+    Args:
+        csr (str): Certificate Signing Request as a string
+        cert (str): Certificate as a string
+    Returns:
+        bool: True/False depending on whether the CSR matches the certificate.
+    """
+    try:
+        csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
+        cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
+
+        if csr_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ) != cert_object.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ):
+            return False
+        if (
+            csr_object.public_key().public_numbers().n  # type: ignore[union-attr]
+            != cert_object.public_key().public_numbers().n  # type: ignore[union-attr]
+        ):
+            return False
+    except ValueError:
+        logger.warning("Could not load certificate or CSR.")
+        return False
+    return True
+
+
+def _relation_data_is_valid(
+    relation: Relation, app_or_unit: Union[Application, Unit], json_schema: dict
+) -> bool:
+    """Check whether relation data is valid based on json schema.
+
+    Args:
+        relation (Relation): Relation object
+        app_or_unit (Union[Application, Unit]): Application or unit object
+        json_schema (dict): Json schema
+
+    Returns:
+        bool: Whether relation data is valid.
+    """
+    relation_data = _load_relation_data(relation.data[app_or_unit])
+    try:
+        validate(instance=relation_data, schema=json_schema)
+        return True
+    except exceptions.ValidationError:
+        return False
+
+
 class CertificatesProviderCharmEvents(CharmEvents):
     """List of events that the TLS Certificates provider charm can leverage."""
 
@@ -898,10 +1164,10 @@ class CertificatesRequirerCharmEvents(CharmEvents):
     all_certificates_invalidated = EventSource(AllCertificatesInvalidatedEvent)
 
 
-class TLSCertificatesProvidesV2(Object):
+class TLSCertificatesProvidesV3(Object):
     """TLS certificates provider class to be instantiated by TLS certificates providers."""
 
-    on = CertificatesProviderCharmEvents()
+    on = CertificatesProviderCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(self, charm: CharmBase, relationship_name: str):
         super().__init__(charm, relationship_name)
@@ -912,12 +1178,12 @@ class TLSCertificatesProvidesV2(Object):
         self.relationship_name = relationship_name
 
     def _load_app_relation_data(self, relation: Relation) -> dict:
-        """Loads relation data from the application relation data bag.
+        """Load relation data from the application relation data bag.
 
         Json loads all data.
 
         Args:
-            relation_object: Relation data from the application databag
+            relation: Relation data from the application databag
 
         Returns:
             dict: Relation data in dict format.
@@ -934,8 +1200,9 @@ class TLSCertificatesProvidesV2(Object):
         certificate_signing_request: str,
         ca: str,
         chain: List[str],
+        recommended_expiry_notification_time: Optional[int] = None,
     ) -> None:
-        """Adds certificate to relation data.
+        """Add certificate to relation data.
 
         Args:
             relation_id (int): Relation id
@@ -943,6 +1210,8 @@ class TLSCertificatesProvidesV2(Object):
             certificate_signing_request (str): Certificate Signing Request
             ca (str): CA Certificate
             chain (list): CA Chain
+            recommended_expiry_notification_time (int):
+                Time in hours before the certificate expires to notify the user.
 
         Returns:
             None
@@ -960,6 +1229,7 @@ class TLSCertificatesProvidesV2(Object):
             "certificate_signing_request": certificate_signing_request,
             "ca": ca,
             "chain": chain,
+            "recommended_expiry_notification_time": recommended_expiry_notification_time,
         }
         provider_relation_data = self._load_app_relation_data(relation)
         provider_certificates = provider_relation_data.get("certificates", [])
@@ -976,7 +1246,7 @@ class TLSCertificatesProvidesV2(Object):
         certificate: Optional[str] = None,
         certificate_signing_request: Optional[str] = None,
     ) -> None:
-        """Removes certificate from a given relation based on user provided certificate or csr.
+        """Remove certificate from a given relation based on user provided certificate or csr.
 
         Args:
             relation_id (int): Relation id
@@ -1007,24 +1277,8 @@ class TLSCertificatesProvidesV2(Object):
                 certificates.remove(certificate_dict)
         relation.data[self.model.app]["certificates"] = json.dumps(certificates)
 
-    @staticmethod
-    def _relation_data_is_valid(certificates_data: dict) -> bool:
-        """Uses JSON schema validator to validate relation data content.
-
-        Args:
-            certificates_data (dict): Certificate data dictionary as retrieved from relation data.
-
-        Returns:
-            bool: True/False depending on whether the relation data follows the json schema.
-        """
-        try:
-            validate(instance=certificates_data, schema=REQUIRER_JSON_SCHEMA)
-            return True
-        except exceptions.ValidationError:
-            return False
-
     def revoke_all_certificates(self) -> None:
-        """Revokes all certificates of this provider.
+        """Revoke all certificates of this provider.
 
         This method is meant to be used when the Root CA has changed.
         """
@@ -1042,8 +1296,9 @@ class TLSCertificatesProvidesV2(Object):
         ca: str,
         chain: List[str],
         relation_id: int,
+        recommended_expiry_notification_time: Optional[int] = None,
     ) -> None:
-        """Adds certificates to relation data.
+        """Add certificates to relation data.
 
         Args:
             certificate (str): Certificate
@@ -1051,6 +1306,8 @@ class TLSCertificatesProvidesV2(Object):
             ca (str): CA Certificate
             chain (list): CA Chain
             relation_id (int): Juju relation ID
+            recommended_expiry_notification_time (int):
+                Recommended time in hours before the certificate expires to notify the user.
 
         Returns:
             None
@@ -1072,10 +1329,11 @@ class TLSCertificatesProvidesV2(Object):
             certificate_signing_request=certificate_signing_request.strip(),
             ca=ca.strip(),
             chain=[cert.strip() for cert in chain],
+            recommended_expiry_notification_time=recommended_expiry_notification_time,
         )
 
     def remove_certificate(self, certificate: str) -> None:
-        """Removes a given certificate from relation data.
+        """Remove a given certificate from relation data.
 
         Args:
             certificate (str): TLS Certificate
@@ -1091,16 +1349,24 @@ class TLSCertificatesProvidesV2(Object):
 
     def get_issued_certificates(
         self, relation_id: Optional[int] = None
-    ) -> Dict[str, List[Dict[str, str]]]:
-        """Returns a dictionary of issued certificates.
-
-        It returns certificates from all relations if relation_id is not specified.
-        Certificates are returned per application name and CSR.
+    ) -> List[ProviderCertificate]:
+        """Return a List of issued (non revoked) certificates.
 
         Returns:
-            dict: Certificates per application name.
+            List: List of ProviderCertificate objects
         """
-        certificates: Dict[str, List[Dict[str, str]]] = {}
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
+        return [certificate for certificate in provider_certificates if not certificate.revoked]
+
+    def get_provider_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return a List of issued certificates.
+
+        Returns:
+            List: List of ProviderCertificate objects
+        """
+        certificates: List[ProviderCertificate] = []
         relations = (
             [
                 relation
@@ -1111,23 +1377,37 @@ class TLSCertificatesProvidesV2(Object):
             else self.model.relations.get(self.relationship_name, [])
         )
         for relation in relations:
+            if not relation.app:
+                logger.warning("Relation %s does not have an application", relation.id)
+                continue
             provider_relation_data = self._load_app_relation_data(relation)
             provider_certificates = provider_relation_data.get("certificates", [])
-
-            certificates[relation.app.name] = []  # type: ignore[union-attr]
             for certificate in provider_certificates:
-                if not certificate.get("revoked", False):
-                    certificates[relation.app.name].append(  # type: ignore[union-attr]
-                        {
-                            "csr": certificate["certificate_signing_request"],
-                            "certificate": certificate["certificate"],
-                        }
+                try:
+                    certificate_object = x509.load_pem_x509_certificate(
+                        data=certificate["certificate"].encode()
                     )
-
+                except ValueError as e:
+                    logger.error("Could not load certificate - Skipping: %s", e)
+                    continue
+                provider_certificate = ProviderCertificate(
+                    relation_id=relation.id,
+                    application_name=relation.app.name,
+                    csr=certificate["certificate_signing_request"],
+                    certificate=certificate["certificate"],
+                    ca=certificate["ca"],
+                    chain=certificate["chain"],
+                    revoked=certificate.get("revoked", False),
+                    expiry_time=certificate_object.not_valid_after_utc,
+                    expiry_notification_time=certificate.get(
+                        "recommended_expiry_notification_time"
+                    ),
+                )
+                certificates.append(provider_certificate)
         return certificates
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggered on relation changed event.
+        """Handle relation changed event.
 
         Looks at the relation data and either emits:
         - certificate request event: If the unit relation data contains a CSR for which
@@ -1146,107 +1426,77 @@ class TLSCertificatesProvidesV2(Object):
             return
         if not self.model.unit.is_leader():
             return
-        requirer_relation_data = _load_relation_data(event.relation.data[event.unit])
-        provider_relation_data = self._load_app_relation_data(event.relation)
-        if not self._relation_data_is_valid(requirer_relation_data):
+        if not _relation_data_is_valid(event.relation, event.unit, REQUIRER_JSON_SCHEMA):
             logger.debug("Relation data did not pass JSON Schema validation")
             return
-        provider_certificates = provider_relation_data.get("certificates", [])
-        requirer_csrs = requirer_relation_data.get("certificate_signing_requests", [])
+        provider_certificates = self.get_provider_certificates(relation_id=event.relation.id)
+        requirer_csrs = self.get_requirer_csrs(relation_id=event.relation.id)
         provider_csrs = [
-            certificate_creation_request["certificate_signing_request"]
+            certificate_creation_request.csr
             for certificate_creation_request in provider_certificates
         ]
-        requirer_unit_csrs = [
-            certificate_creation_request["certificate_signing_request"]
-            for certificate_creation_request in requirer_csrs
-        ]
-        for certificate_signing_request in requirer_unit_csrs:
-            if certificate_signing_request not in provider_csrs:
+        for certificate_request in requirer_csrs:
+            if certificate_request.csr not in provider_csrs:
                 self.on.certificate_creation_request.emit(
-                    certificate_signing_request=certificate_signing_request,
-                    relation_id=event.relation.id,
+                    certificate_signing_request=certificate_request.csr,
+                    relation_id=certificate_request.relation_id,
+                    is_ca=certificate_request.is_ca,
                 )
         self._revoke_certificates_for_which_no_csr_exists(relation_id=event.relation.id)
 
     def _revoke_certificates_for_which_no_csr_exists(self, relation_id: int) -> None:
-        """Revokes certificates for which no unit has a CSR.
+        """Revoke certificates for which no unit has a CSR.
 
-        Goes through all generated certificates and compare against the list of CSRs for all units
-        of a given relationship.
-
-        Args:
-            relation_id (int): Relation id
+        Goes through all generated certificates and compare against the list of CSRs for all units.
 
         Returns:
             None
         """
-        certificates_relation = self.model.get_relation(
-            relation_name=self.relationship_name, relation_id=relation_id
-        )
-        if not certificates_relation:
-            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
-        provider_relation_data = self._load_app_relation_data(certificates_relation)
-        list_of_csrs: List[str] = []
-        for unit in certificates_relation.units:
-            requirer_relation_data = _load_relation_data(certificates_relation.data[unit])
-            requirer_csrs = requirer_relation_data.get("certificate_signing_requests", [])
-            list_of_csrs.extend(csr["certificate_signing_request"] for csr in requirer_csrs)
-        provider_certificates = provider_relation_data.get("certificates", [])
+        provider_certificates = self.get_provider_certificates(relation_id)
+        requirer_csrs = self.get_requirer_csrs(relation_id)
+        list_of_csrs = [csr.csr for csr in requirer_csrs]
         for certificate in provider_certificates:
-            if certificate["certificate_signing_request"] not in list_of_csrs:
+            if certificate.csr not in list_of_csrs:
                 self.on.certificate_revocation_request.emit(
-                    certificate=certificate["certificate"],
-                    certificate_signing_request=certificate["certificate_signing_request"],
-                    ca=certificate["ca"],
-                    chain=certificate["chain"],
+                    certificate=certificate.certificate,
+                    certificate_signing_request=certificate.csr,
+                    ca=certificate.ca,
+                    chain=certificate.chain,
                 )
-                self.remove_certificate(certificate=certificate["certificate"])
+                self.remove_certificate(certificate=certificate.certificate)
 
-    def get_requirer_csrs_with_no_certs(
+    def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None
-    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
-        """Filters the requirer's units csrs.
-
-        Keeps the ones for which no certificate was provided.
+    ) -> List[RequirerCSR]:
+        """Return CSR's for which no certificate has been issued.
 
         Args:
             relation_id (int): Relation id
 
         Returns:
-            list: List of dictionaries that contain the unit's csrs
-            that don't have a certificate issued.
+            list: List of RequirerCSR objects.
         """
-        all_unit_csr_mappings = copy.deepcopy(self.get_requirer_csrs(relation_id=relation_id))
-        filtered_all_unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
-        for unit_csr_mapping in all_unit_csr_mappings:
-            csrs_without_certs = []
-            for csr in unit_csr_mapping["unit_csrs"]:  # type: ignore[union-attr]
-                if not self.certificate_issued_for_csr(
-                    app_name=unit_csr_mapping["application_name"],  # type: ignore[arg-type]
-                    csr=csr["certificate_signing_request"],  # type: ignore[index]
-                ):
-                    csrs_without_certs.append(csr)
-            if csrs_without_certs:
-                unit_csr_mapping["unit_csrs"] = csrs_without_certs  # type: ignore[assignment]
-                filtered_all_unit_csr_mappings.append(unit_csr_mapping)
-        return filtered_all_unit_csr_mappings
+        requirer_csrs = self.get_requirer_csrs(relation_id=relation_id)
+        outstanding_csrs: List[RequirerCSR] = []
+        for relation_csr in requirer_csrs:
+            if not self.certificate_issued_for_csr(
+                app_name=relation_csr.application_name,
+                csr=relation_csr.csr,
+                relation_id=relation_id,
+            ):
+                outstanding_csrs.append(relation_csr)
+        return outstanding_csrs
 
-    def get_requirer_csrs(
-        self, relation_id: Optional[int] = None
-    ) -> List[Dict[str, Union[int, str, List[Dict[str, str]]]]]:
-        """Returns a list of requirers' CSRs grouped by unit.
+    def get_requirer_csrs(self, relation_id: Optional[int] = None) -> List[RequirerCSR]:
+        """Return a list of requirers' CSRs.
 
         It returns CSRs from all relations if relation_id is not specified.
         CSRs are returned per relation id, application name and unit name.
 
         Returns:
-            list: List of dictionaries that contain the unit's csrs
-            with the following information
-            relation_id, application_name and unit_name.
+            list: List[RequirerCSR]
         """
-        unit_csr_mappings: List[Dict[str, Union[int, str, List[Dict[str, str]]]]] = []
-
+        relation_csrs: List[RequirerCSR] = []
         relations = (
             [
                 relation
@@ -1261,53 +1511,69 @@ class TLSCertificatesProvidesV2(Object):
             for unit in relation.units:
                 requirer_relation_data = _load_relation_data(relation.data[unit])
                 unit_csrs_list = requirer_relation_data.get("certificate_signing_requests", [])
-                unit_csr_mappings.append(
-                    {
-                        "relation_id": relation.id,
-                        "application_name": relation.app.name,  # type: ignore[union-attr]
-                        "unit_name": unit.name,
-                        "unit_csrs": unit_csrs_list,
-                    }
-                )
-        return unit_csr_mappings
+                for unit_csr in unit_csrs_list:
+                    csr = unit_csr.get("certificate_signing_request")
+                    if not csr:
+                        logger.warning("No CSR found in relation data - Skipping")
+                        continue
+                    ca = unit_csr.get("ca", False)
+                    if not relation.app:
+                        logger.warning("No remote app in relation - Skipping")
+                        continue
+                    relation_csr = RequirerCSR(
+                        relation_id=relation.id,
+                        application_name=relation.app.name,
+                        unit_name=unit.name,
+                        csr=csr,
+                        is_ca=ca,
+                    )
+                    relation_csrs.append(relation_csr)
+        return relation_csrs
 
-    def certificate_issued_for_csr(self, app_name: str, csr: str) -> bool:
-        """Checks whether a certificate has been issued for a given CSR.
+    def certificate_issued_for_csr(
+        self, app_name: str, csr: str, relation_id: Optional[int]
+    ) -> bool:
+        """Check whether a certificate has been issued for a given CSR.
 
         Args:
             app_name (str): Application name that the CSR belongs to.
             csr (str): Certificate Signing Request.
+            relation_id (Optional[int]): Relation ID
 
         Returns:
             bool: True/False depending on whether a certificate has been issued for the given CSR.
         """
-        issued_certificates_per_csr = self.get_issued_certificates()[app_name]
-        for issued_pair in issued_certificates_per_csr:
-            if "csr" in issued_pair and issued_pair["csr"] == csr:
-                return csr_matches_certificate(csr, issued_pair["certificate"])
+        issued_certificates_per_csr = self.get_issued_certificates(relation_id=relation_id)
+        for issued_certificate in issued_certificates_per_csr:
+            if issued_certificate.csr == csr and issued_certificate.application_name == app_name:
+                return csr_matches_certificate(csr, issued_certificate.certificate)
         return False
 
 
-class TLSCertificatesRequiresV2(Object):
+class TLSCertificatesRequiresV3(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
-    on = CertificatesRequirerCharmEvents()
+    on = CertificatesRequirerCharmEvents()  # type: ignore[reportAssignmentType]
 
     def __init__(
         self,
         charm: CharmBase,
         relationship_name: str,
-        expiry_notification_time: int = 168,
+        expiry_notification_time: Optional[int] = None,
     ):
-        """Generates/use private key and observes relation changed event.
+        """Generate/use private key and observes relation changed event.
 
         Args:
             charm: Charm object
             relationship_name: Juju relation name
-            expiry_notification_time (int): Time difference between now and expiry (in hours).
-                Used to trigger the CertificateExpiring event. Default: 7 days.
+            expiry_notification_time (int): Number of hours prior to certificate expiry.
+                Used to trigger the CertificateExpiring event.
+                This value is used as a recommendation only,
+                The actual value is calculated taking into account the provider's recommendation.
         """
         super().__init__(charm, relationship_name)
+        if not JujuVersion.from_environ().has_secrets:
+            logger.warning("This version of the TLS library requires Juju secrets (Juju >= 3.0)")
         self.relationship_name = relationship_name
         self.charm = charm
         self.expiry_notification_time = expiry_notification_time
@@ -1317,23 +1583,39 @@ class TLSCertificatesRequiresV2(Object):
         self.framework.observe(
             charm.on[relationship_name].relation_broken, self._on_relation_broken
         )
-        if JujuVersion.from_environ().has_secrets:
-            self.framework.observe(charm.on.secret_expired, self._on_secret_expired)
-        else:
-            self.framework.observe(charm.on.update_status, self._on_update_status)
+        self.framework.observe(charm.on.secret_expired, self._on_secret_expired)
 
-    @property
-    def _requirer_csrs(self) -> List[Dict[str, str]]:
-        """Returns list of requirer's CSRs from relation data."""
+    def get_requirer_csrs(self) -> List[RequirerCSR]:
+        """Return list of requirer's CSRs from relation unit data.
+
+        Returns:
+            list: List of RequirerCSR objects.
+        """
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
-            raise RuntimeError(f"Relation {self.relationship_name} does not exist")
+            return []
+        requirer_csrs = []
         requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
-        return requirer_relation_data.get("certificate_signing_requests", [])
+        requirer_csrs_dict = requirer_relation_data.get("certificate_signing_requests", [])
+        for requirer_csr_dict in requirer_csrs_dict:
+            csr = requirer_csr_dict.get("certificate_signing_request")
+            if not csr:
+                logger.warning("No CSR found in relation data - Skipping")
+                continue
+            ca = requirer_csr_dict.get("ca", False)
+            relation_csr = RequirerCSR(
+                relation_id=relation.id,
+                application_name=self.model.app.name,
+                unit_name=self.model.unit.name,
+                csr=csr,
+                is_ca=ca,
+            )
+            requirer_csrs.append(relation_csr)
+        return requirer_csrs
 
-    @property
-    def _provider_certificates(self) -> List[Dict[str, str]]:
-        """Returns list of certificates from the provider's relation data."""
+    def get_provider_certificates(self) -> List[ProviderCertificate]:
+        """Return list of certificates from the provider's relation data."""
+        provider_certificates: List[ProviderCertificate] = []
         relation = self.model.get_relation(self.relationship_name)
         if not relation:
             logger.debug("No relation: %s", self.relationship_name)
@@ -1342,16 +1624,55 @@ class TLSCertificatesRequiresV2(Object):
             logger.debug("No remote app in relation: %s", self.relationship_name)
             return []
         provider_relation_data = _load_relation_data(relation.data[relation.app])
-        if not self._relation_data_is_valid(provider_relation_data):
-            logger.warning("Provider relation data did not pass JSON Schema validation")
-            return []
-        return provider_relation_data.get("certificates", [])
+        provider_certificate_dicts = provider_relation_data.get("certificates", [])
+        for provider_certificate_dict in provider_certificate_dicts:
+            certificate = provider_certificate_dict.get("certificate")
+            if not certificate:
+                logger.warning("No certificate found in relation data - Skipping")
+                continue
+            try:
+                certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
+            except ValueError as e:
+                logger.error("Could not load certificate - Skipping: %s", e)
+                continue
+            ca = provider_certificate_dict.get("ca")
+            chain = provider_certificate_dict.get("chain", [])
+            csr = provider_certificate_dict.get("certificate_signing_request")
+            recommended_expiry_notification_time = provider_certificate_dict.get(
+                "recommended_expiry_notification_time"
+            )
+            expiry_time = certificate_object.not_valid_after_utc
+            validity_start_time = certificate_object.not_valid_before_utc
+            expiry_notification_time = calculate_expiry_notification_time(
+                validity_start_time=validity_start_time,
+                expiry_time=expiry_time,
+                provider_recommended_notification_time=recommended_expiry_notification_time,
+                requirer_recommended_notification_time=self.expiry_notification_time,
+            )
+            if not csr:
+                logger.warning("No CSR found in relation data - Skipping")
+                continue
+            revoked = provider_certificate_dict.get("revoked", False)
+            provider_certificate = ProviderCertificate(
+                relation_id=relation.id,
+                application_name=relation.app.name,
+                csr=csr,
+                certificate=certificate,
+                ca=ca,
+                chain=chain,
+                revoked=revoked,
+                expiry_time=expiry_time,
+                expiry_notification_time=expiry_notification_time,
+            )
+            provider_certificates.append(provider_certificate)
+        return provider_certificates
 
-    def _add_requirer_csr(self, csr: str) -> None:
-        """Adds CSR to relation data.
+    def _add_requirer_csr_to_relation_data(self, csr: str, is_ca: bool) -> None:
+        """Add CSR to relation data.
 
         Args:
             csr (str): Certificate Signing Request
+            is_ca (bool): Whether the certificate is a CA certificate
 
         Returns:
             None
@@ -1362,16 +1683,24 @@ class TLSCertificatesRequiresV2(Object):
                 f"Relation {self.relationship_name} does not exist - "
                 f"The certificate request can't be completed"
             )
-        new_csr_dict = {"certificate_signing_request": csr}
-        if new_csr_dict in self._requirer_csrs:
-            logger.info("CSR already in relation data - Doing nothing")
-            return
-        requirer_csrs = copy.deepcopy(self._requirer_csrs)
-        requirer_csrs.append(new_csr_dict)
-        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
+        for requirer_csr in self.get_requirer_csrs():
+            if requirer_csr.csr == csr and requirer_csr.is_ca == is_ca:
+                logger.info("CSR already in relation data - Doing nothing")
+                return
+        new_csr_dict = {
+            "certificate_signing_request": csr,
+            "ca": is_ca,
+        }
+        requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
+        existing_relation_data = requirer_relation_data.get("certificate_signing_requests", [])
+        new_relation_data = copy.deepcopy(existing_relation_data)
+        new_relation_data.append(new_csr_dict)
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(
+            new_relation_data
+        )
 
-    def _remove_requirer_csr(self, csr: str) -> None:
-        """Removes CSR from relation data.
+    def _remove_requirer_csr_from_relation_data(self, csr: str) -> None:
+        """Remove CSR from relation data.
 
         Args:
             csr (str): Certificate signing request
@@ -1385,19 +1714,27 @@ class TLSCertificatesRequiresV2(Object):
                 f"Relation {self.relationship_name} does not exist - "
                 f"The certificate request can't be completed"
             )
-        requirer_csrs = copy.deepcopy(self._requirer_csrs)
-        csr_dict = {"certificate_signing_request": csr}
-        if csr_dict not in requirer_csrs:
-            logger.info("CSR not in relation data - Doing nothing")
+        if not self.get_requirer_csrs():
+            logger.info("No CSRs in relation data - Doing nothing")
             return
-        requirer_csrs.remove(csr_dict)
-        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(requirer_csrs)
+        requirer_relation_data = _load_relation_data(relation.data[self.model.unit])
+        existing_relation_data = requirer_relation_data.get("certificate_signing_requests", [])
+        new_relation_data = copy.deepcopy(existing_relation_data)
+        for requirer_csr in new_relation_data:
+            if requirer_csr["certificate_signing_request"] == csr:
+                new_relation_data.remove(requirer_csr)
+        relation.data[self.model.unit]["certificate_signing_requests"] = json.dumps(
+            new_relation_data
+        )
 
-    def request_certificate_creation(self, certificate_signing_request: bytes) -> None:
+    def request_certificate_creation(
+        self, certificate_signing_request: bytes, is_ca: bool = False
+    ) -> None:
         """Request TLS certificate to provider charm.
 
         Args:
             certificate_signing_request (bytes): Certificate Signing Request
+            is_ca (bool): Whether the certificate is a CA certificate
 
         Returns:
             None
@@ -1408,11 +1745,13 @@ class TLSCertificatesRequiresV2(Object):
                 f"Relation {self.relationship_name} does not exist - "
                 f"The certificate request can't be completed"
             )
-        self._add_requirer_csr(certificate_signing_request.decode().strip())
+        self._add_requirer_csr_to_relation_data(
+            certificate_signing_request.decode().strip(), is_ca=is_ca
+        )
         logger.info("Certificate request sent to provider")
 
     def request_certificate_revocation(self, certificate_signing_request: bytes) -> None:
-        """Removes CSR from relation data.
+        """Remove CSR from relation data.
 
         The provider of this relation is then expected to remove certificates associated to this
         CSR from the relation data as well and emit a request_certificate_revocation event for the
@@ -1424,13 +1763,13 @@ class TLSCertificatesRequiresV2(Object):
         Returns:
             None
         """
-        self._remove_requirer_csr(certificate_signing_request.decode().strip())
+        self._remove_requirer_csr_from_relation_data(certificate_signing_request.decode().strip())
         logger.info("Certificate revocation sent to provider")
 
     def request_certificate_renewal(
         self, old_certificate_signing_request: bytes, new_certificate_signing_request: bytes
     ) -> None:
-        """Renews certificate.
+        """Renew certificate.
 
         Removes old CSR from relation data and adds new one.
 
@@ -1452,33 +1791,69 @@ class TLSCertificatesRequiresV2(Object):
         )
         logger.info("Certificate renewal request completed.")
 
-    @staticmethod
-    def _relation_data_is_valid(certificates_data: dict) -> bool:
-        """Checks whether relation data is valid based on json schema.
-
-        Args:
-            certificates_data: Certificate data in dict format.
+    def get_assigned_certificates(self) -> List[ProviderCertificate]:
+        """Get a list of certificates that were assigned to this unit.
 
         Returns:
-            bool: Whether relation data is valid.
+            List: List[ProviderCertificate]
         """
-        try:
-            validate(instance=certificates_data, schema=PROVIDER_JSON_SCHEMA)
-            return True
-        except exceptions.ValidationError:
-            return False
+        assigned_certificates = []
+        for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            if cert := self._find_certificate_in_relation_data(requirer_csr.csr):
+                assigned_certificates.append(cert)
+        return assigned_certificates
+
+    def get_expiring_certificates(self) -> List[ProviderCertificate]:
+        """Get a list of certificates that were assigned to this unit that are expiring or expired.
+
+        Returns:
+            List: List[ProviderCertificate]
+        """
+        expiring_certificates: List[ProviderCertificate] = []
+        for requirer_csr in self.get_certificate_signing_requests(fulfilled_only=True):
+            if cert := self._find_certificate_in_relation_data(requirer_csr.csr):
+                if not cert.expiry_time or not cert.expiry_notification_time:
+                    continue
+                if datetime.now(timezone.utc) > cert.expiry_notification_time:
+                    expiring_certificates.append(cert)
+        return expiring_certificates
+
+    def get_certificate_signing_requests(
+        self,
+        fulfilled_only: bool = False,
+        unfulfilled_only: bool = False,
+    ) -> List[RequirerCSR]:
+        """Get the list of CSR's that were sent to the provider.
+
+        You can choose to get only the CSR's that have a certificate assigned or only the CSR's
+        that don't.
+
+        Args:
+            fulfilled_only (bool): This option will discard CSRs that don't have certificates yet.
+            unfulfilled_only (bool): This option will discard CSRs that have certificates signed.
+
+        Returns:
+            List of RequirerCSR objects.
+        """
+        csrs = []
+        for requirer_csr in self.get_requirer_csrs():
+            cert = self._find_certificate_in_relation_data(requirer_csr.csr)
+            if (unfulfilled_only and cert) or (fulfilled_only and not cert):
+                continue
+            csrs.append(requirer_csr)
+
+        return csrs
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggered on relation changed events.
+        """Handle relation changed event.
 
         Goes through all providers certificates that match a requested CSR.
 
         If the provider certificate is revoked, emit a CertificateInvalidateEvent,
         otherwise emit a CertificateAvailableEvent.
 
-        When Juju secrets are available, remove the secret for revoked certificate,
-        or add a secret with the correct expiry time for new certificates.
-
+        Remove the secret for revoked certificate, or add a secret with the correct expiry
+        time for new certificates.
 
         Args:
             event: Juju event
@@ -1486,54 +1861,52 @@ class TLSCertificatesRequiresV2(Object):
         Returns:
             None
         """
+        if not event.app:
+            logger.warning("No remote app in relation - Skipping")
+            return
+        if not _relation_data_is_valid(event.relation, event.app, PROVIDER_JSON_SCHEMA):
+            logger.debug("Relation data did not pass JSON Schema validation")
+            return
+        provider_certificates = self.get_provider_certificates()
         requirer_csrs = [
-            certificate_creation_request["certificate_signing_request"]
-            for certificate_creation_request in self._requirer_csrs
+            certificate_creation_request.csr
+            for certificate_creation_request in self.get_requirer_csrs()
         ]
-        for certificate in self._provider_certificates:
-            if certificate["certificate_signing_request"] in requirer_csrs:
-                if certificate.get("revoked", False):
-                    if JujuVersion.from_environ().has_secrets:
-                        with suppress(SecretNotFoundError):
-                            secret = self.model.get_secret(
-                                label=f"{LIBID}-{certificate['certificate_signing_request']}"
-                            )
-                            secret.remove_all_revisions()
+        for certificate in provider_certificates:
+            if certificate.csr in requirer_csrs:
+                if certificate.revoked:
+                    with suppress(SecretNotFoundError):
+                        secret = self.model.get_secret(label=f"{LIBID}-{certificate.csr}")
+                        secret.remove_all_revisions()
                     self.on.certificate_invalidated.emit(
                         reason="revoked",
-                        certificate=certificate["certificate"],
-                        certificate_signing_request=certificate["certificate_signing_request"],
-                        ca=certificate["ca"],
-                        chain=certificate["chain"],
+                        certificate=certificate.certificate,
+                        certificate_signing_request=certificate.csr,
+                        ca=certificate.ca,
+                        chain=certificate.chain,
                     )
                 else:
-                    if JujuVersion.from_environ().has_secrets:
-                        try:
-                            secret = self.model.get_secret(
-                                label=f"{LIBID}-{certificate['certificate_signing_request']}"
-                            )
-                            secret.set_content({"certificate": certificate["certificate"]})
-                            secret.set_info(
-                                expire=self._get_next_secret_expiry_time(
-                                    certificate["certificate"]
-                                ),
-                            )
-                        except SecretNotFoundError:
-                            secret = self.charm.unit.add_secret(
-                                {"certificate": certificate["certificate"]},
-                                label=f"{LIBID}-{certificate['certificate_signing_request']}",
-                                expire=self._get_next_secret_expiry_time(
-                                    certificate["certificate"]
-                                ),
-                            )
+                    try:
+                        secret = self.model.get_secret(label=f"{LIBID}-{certificate.csr}")
+                        secret.set_content({"certificate": certificate.certificate})
+                        secret.set_info(
+                            expire=self._get_next_secret_expiry_time(certificate),
+                        )
+                    except SecretNotFoundError:
+                        logger.debug("Adding secret with label %s", f"{LIBID}-{certificate.csr}")
+                        secret = self.charm.unit.add_secret(
+                            {"certificate": certificate.certificate},
+                            label=f"{LIBID}-{certificate.csr}",
+                            expire=self._get_next_secret_expiry_time(certificate),
+                        )
                     self.on.certificate_available.emit(
-                        certificate_signing_request=certificate["certificate_signing_request"],
-                        certificate=certificate["certificate"],
-                        ca=certificate["ca"],
-                        chain=certificate["chain"],
+                        certificate_signing_request=certificate.csr,
+                        certificate=certificate.certificate,
+                        ca=certificate.ca,
+                        chain=certificate.chain,
                     )
 
-    def _get_next_secret_expiry_time(self, certificate: str) -> Optional[datetime]:
+    def _get_next_secret_expiry_time(self, certificate: ProviderCertificate) -> Optional[datetime]:
         """Return the expiry time or expiry notification time.
 
         Extracts the expiry time from the provided certificate, calculates the
@@ -1541,20 +1914,21 @@ class TLSCertificatesRequiresV2(Object):
         the future.
 
         Args:
-            certificate: x509 certificate
+            certificate: ProviderCertificate object
 
         Returns:
             Optional[datetime]: None if the certificate expiry time cannot be read,
                                 next expiry time otherwise.
         """
-        expiry_time = _get_certificate_expiry_time(certificate)
-        if not expiry_time:
+        if not certificate.expiry_time or not certificate.expiry_notification_time:
             return None
-        expiry_notification_time = expiry_time - timedelta(hours=self.expiry_notification_time)
-        return _get_closest_future_time(expiry_notification_time, expiry_time)
+        return _get_closest_future_time(
+            certificate.expiry_notification_time,
+            certificate.expiry_time,
+        )
 
     def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Handler triggered on relation broken event.
+        """Handle Relation Broken Event.
 
         Emitting `all_certificates_invalidated` from `relation-broken` rather
         than `relation-departed` since certs are stored in app data.
@@ -1568,7 +1942,7 @@ class TLSCertificatesRequiresV2(Object):
         self.on.all_certificates_invalidated.emit()
 
     def _on_secret_expired(self, event: SecretExpiredEvent) -> None:
-        """Triggered when a certificate is set to expire.
+        """Handle Secret Expired Event.
 
         Loads the certificate from the secret, and will emit 1 of 2
         events.
@@ -1586,144 +1960,42 @@ class TLSCertificatesRequiresV2(Object):
         if not event.secret.label or not event.secret.label.startswith(f"{LIBID}-"):
             return
         csr = event.secret.label[len(f"{LIBID}-") :]
-        certificate_dict = self._find_certificate_in_relation_data(csr)
-        if not certificate_dict:
+        provider_certificate = self._find_certificate_in_relation_data(csr)
+        if not provider_certificate:
             # A secret expired but we did not find matching certificate. Cleaning up
             event.secret.remove_all_revisions()
             return
 
-        expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
-        if not expiry_time:
+        if not provider_certificate.expiry_time:
             # A secret expired but matching certificate is invalid. Cleaning up
             event.secret.remove_all_revisions()
             return
 
-        if datetime.utcnow() < expiry_time:
+        if datetime.now(timezone.utc) < provider_certificate.expiry_time:
             logger.warning("Certificate almost expired")
             self.on.certificate_expiring.emit(
-                certificate=certificate_dict["certificate"],
-                expiry=expiry_time.isoformat(),
+                certificate=provider_certificate.certificate,
+                expiry=provider_certificate.expiry_time.isoformat(),
             )
             event.secret.set_info(
-                expire=_get_certificate_expiry_time(certificate_dict["certificate"]),
+                expire=provider_certificate.expiry_time,
             )
         else:
             logger.warning("Certificate is expired")
             self.on.certificate_invalidated.emit(
                 reason="expired",
-                certificate=certificate_dict["certificate"],
-                certificate_signing_request=certificate_dict["certificate_signing_request"],
-                ca=certificate_dict["ca"],
-                chain=certificate_dict["chain"],
+                certificate=provider_certificate.certificate,
+                certificate_signing_request=provider_certificate.csr,
+                ca=provider_certificate.ca,
+                chain=provider_certificate.chain,
             )
-            self.request_certificate_revocation(certificate_dict["certificate"].encode())
+            self.request_certificate_revocation(provider_certificate.certificate.encode())
             event.secret.remove_all_revisions()
 
-    def _find_certificate_in_relation_data(self, csr: str) -> Optional[Dict[str, Any]]:
-        """Returns the certificate that match the given CSR."""
-        for certificate_dict in self._provider_certificates:
-            if certificate_dict["certificate_signing_request"] != csr:
+    def _find_certificate_in_relation_data(self, csr: str) -> Optional[ProviderCertificate]:
+        """Return the certificate that match the given CSR."""
+        for provider_certificate in self.get_provider_certificates():
+            if provider_certificate.csr != csr:
                 continue
-            return certificate_dict
-        return None
-
-    def _on_update_status(self, event: UpdateStatusEvent) -> None:
-        """Triggered on update status event.
-
-        Goes through each certificate in the "certificates" relation and checks their expiry date.
-        If they are close to expire (<7 days), emits a CertificateExpiringEvent event and if
-        they are expired, emits a CertificateExpiredEvent.
-
-        Args:
-            event (UpdateStatusEvent): Juju event
-
-        Returns:
-            None
-        """
-        for certificate_dict in self._provider_certificates:
-            expiry_time = _get_certificate_expiry_time(certificate_dict["certificate"])
-            if not expiry_time:
-                continue
-            time_difference = expiry_time - datetime.utcnow()
-            if time_difference.total_seconds() < 0:
-                logger.warning("Certificate is expired")
-                self.on.certificate_invalidated.emit(
-                    reason="expired",
-                    certificate=certificate_dict["certificate"],
-                    certificate_signing_request=certificate_dict["certificate_signing_request"],
-                    ca=certificate_dict["ca"],
-                    chain=certificate_dict["chain"],
-                )
-                self.request_certificate_revocation(certificate_dict["certificate"].encode())
-                continue
-            if time_difference.total_seconds() < (self.expiry_notification_time * 60 * 60):
-                logger.warning("Certificate almost expired")
-                self.on.certificate_expiring.emit(
-                    certificate=certificate_dict["certificate"],
-                    expiry=expiry_time.isoformat(),
-                )
-
-
-def csr_matches_certificate(csr: str, cert: str) -> bool:
-    """Check if a CSR matches a certificate.
-
-    expects to get the original string representations.
-
-    Args:
-        csr (str): Certificate Signing Request
-        cert (str): Certificate
-    Returns:
-        bool: True/False depending on whether the CSR matches the certificate.
-    """
-    try:
-        csr_object = x509.load_pem_x509_csr(csr.encode("utf-8"))
-        cert_object = x509.load_pem_x509_certificate(cert.encode("utf-8"))
-
-        if csr_object.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ) != cert_object.public_key().public_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo,
-        ):
-            return False
-        if csr_object.subject != cert_object.subject:
-            return False
-    except ValueError:
-        logger.warning("Could not load certificate or CSR.")
-        return False
-    return True
-
-
-def _get_closest_future_time(
-    expiry_notification_time: datetime, expiry_time: datetime
-) -> datetime:
-    """Return expiry_notification_time if not in the past, otherwise return expiry_time.
-
-    Args:
-        expiry_notification_time (datetime): Notification time of impending expiration
-        expiry_time (datetime): Expiration time
-
-    Returns:
-        datetime: expiry_notification_time if not in the past, expiry_time otherwise
-    """
-    return (
-        expiry_notification_time if datetime.utcnow() < expiry_notification_time else expiry_time
-    )
-
-
-def _get_certificate_expiry_time(certificate: str) -> Optional[datetime]:
-    """Extract expiry time from a certificate string.
-
-    Args:
-        certificate (str): x509 certificate as a string
-
-    Returns:
-        Optional[datetime]: Expiry datetime or None
-    """
-    try:
-        certificate_object = x509.load_pem_x509_certificate(data=certificate.encode())
-        return certificate_object.not_valid_after
-    except ValueError:
-        logger.warning("Could not load certificate.")
+            return provider_certificate
         return None

--- a/tests/integration/provider_charm/src/charm.py
+++ b/tests/integration/provider_charm/src/charm.py
@@ -31,8 +31,8 @@ class SampleTLSCertificatesProviderCharm(CharmBase):
         )
 
     @property
-    def _self_signed_ca_certificate(self) -> Optional[str]:
-        return self._get_value_from_relation_data("self_signed_ca_certificate")
+    def _self_signed_ca_certificate(self) -> str:
+        return self._get_value_from_relation_data("self_signed_ca_certificate") or ""
 
     @property
     def _self_signed_ca_private_key(self) -> Optional[str]:
@@ -185,7 +185,7 @@ class SampleTLSCertificatesProviderCharm(CharmBase):
             ca=self._self_signed_ca_certificate,
             chain=ca_chain,
             relation_id=event.relation_id,
-            recommended_expiry_notification_time=720,
+            recommended_expiry_notification_time=0,
         )
         self.unit.status = ActiveStatus()
 

--- a/tests/integration/provider_charm/src/charm.py
+++ b/tests/integration/provider_charm/src/charm.py
@@ -5,9 +5,9 @@
 import logging
 from typing import Optional
 
-from charms.tls_certificates_interface.v2.tls_certificates import (
+from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateCreationRequestEvent,
-    TLSCertificatesProvidesV2,
+    TLSCertificatesProvidesV3,
 )
 from ops.charm import CharmBase, InstallEvent
 from ops.main import main
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 class SampleTLSCertificatesProviderCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.certificates = TLSCertificatesProvidesV2(self, "certificates")
+        self.certificates = TLSCertificatesProvidesV3(self, "certificates")
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(
             self.certificates.on.certificate_creation_request,
@@ -185,6 +185,7 @@ class SampleTLSCertificatesProviderCharm(CharmBase):
             ca=self._self_signed_ca_certificate,
             chain=ca_chain,
             relation_id=event.relation_id,
+            recommended_expiry_notification_time=720,
         )
         self.unit.status = ActiveStatus()
 

--- a/tests/unit/test_cert_relation.py
+++ b/tests/unit/test_cert_relation.py
@@ -12,7 +12,7 @@ import kubernetes
 import kubernetes.client
 import ops
 import pytest
-from charms.tls_certificates_interface.v2.tls_certificates import (
+from charms.tls_certificates_interface.v3.tls_certificates import (
     CertificateAvailableEvent,
     CertificateInvalidatedEvent,
 )
@@ -156,8 +156,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("tls_relation.TLSRelationService.get_relation_data_field")
     @patch("tls_relation.generate_csr")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_creation"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_creation"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("ops.model.Model.get_secret")
@@ -323,8 +323,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("ops.model.Model.get_secret")
     @patch("charm.NginxIngressCharm._on_certificates_relation_created")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_revocation"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_revocation"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("ops.JujuVersion.has_secrets")
@@ -366,8 +366,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("ops.model.Model.get_secret")
     @patch("charm.NginxIngressCharm._on_certificates_relation_created")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_revocation"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_revocation"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("ops.JujuVersion.has_secrets")
@@ -411,8 +411,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("ops.model.Model.get_secret")
     @patch("charm.NginxIngressCharm._on_certificates_relation_created")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_revocation"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_revocation"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("ops.JujuVersion.has_secrets")
@@ -459,8 +459,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("ops.model.Model.get_secret")
     @patch("charm.NginxIngressCharm._on_certificates_relation_created")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_revocation"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_revocation"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("ops.JujuVersion.has_secrets")
@@ -508,8 +508,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("ops.model.Model.get_secret")
     @patch("charm.NginxIngressCharm._on_certificates_relation_created")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_revocation"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_revocation"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @pytest.mark.usefixtures("patch_load_incluster_config")
@@ -552,8 +552,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("ops.model.Model.get_secret")
     @patch("charm.NginxIngressCharm._on_certificates_relation_created")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_renewal"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_renewal"
     )
     @patch("charm.NginxIngressCharm._cleanup")
     def test_certificate_revoked_no_nginx_relation(
@@ -586,8 +586,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("ops.model.Model.get_secret")
     @patch("charm.NginxIngressCharm._on_certificates_relation_created")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_renewal"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_renewal"
     )
     def test_certificate_revoked_no_tls_relation(
         self,
@@ -612,8 +612,8 @@ class TestCertificatesRelation(unittest.TestCase):
 
     @pytest.mark.usefixtures("patch_load_incluster_config")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_renewal"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_renewal"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("tls_relation.TLSRelationService.get_relation_data_field")
@@ -654,8 +654,8 @@ class TestCertificatesRelation(unittest.TestCase):
 
     @pytest.mark.usefixtures("patch_load_incluster_config")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_renewal"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_renewal"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("tls_relation.TLSRelationService.get_relation_data_field")
@@ -685,8 +685,8 @@ class TestCertificatesRelation(unittest.TestCase):
 
     @pytest.mark.usefixtures("patch_load_incluster_config")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_renewal"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_renewal"
     )
     def test_certificate_expiring_no_tls_relation(self, mock_cert_renewal):
         """
@@ -707,8 +707,8 @@ class TestCertificatesRelation(unittest.TestCase):
 
     @pytest.mark.usefixtures("patch_load_incluster_config")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_renewal"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_renewal"
     )
     @patch("charm.NginxIngressCharm._cleanup")
     def test_certificate_expiring_no_nginx_relation(self, mock_cleanup, mock_cert_renewal):
@@ -806,8 +806,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("tls_relation.TLSRelationService.get_relation_data_field")
     @patch("tls_relation.generate_csr")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_creation"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_creation"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     def test_certificate_relation_joined(
@@ -831,8 +831,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("charm.NginxIngressCharm._cleanup")
     @patch("tls_relation.generate_csr")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_creation"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_creation"
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     def test_certificate_relation_joined_no_nginx_relation(
@@ -854,8 +854,8 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("charm.NginxIngressCharm._cleanup")
     @patch("tls_relation.generate_csr")
     @patch(
-        "charms.tls_certificates_interface.v2.tls_certificates"
-        ".TLSCertificatesRequiresV2.request_certificate_creation"
+        "charms.tls_certificates_interface.v3.tls_certificates"
+        ".TLSCertificatesRequiresV3.request_certificate_creation"
     )
     def test_certificate_relation_joined_no_cert_relation(
         self, mock_create_cert, mock_gen_csr, mock_cleanup

--- a/tests/unit/test_cert_relation.py
+++ b/tests/unit/test_cert_relation.py
@@ -253,14 +253,16 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("charm.NginxIngressCharm._cleanup")
     @patch("charm.NginxIngressCharm._certificate_revoked")
     @patch("charm.NginxIngressCharm._update_ingress")
+    @patch("tls_relation.TLSRelationService.get_hostname_from_cert")
     def test_on_certificate_invalidated_revoke(
-        self, mock_update_ingress, mock_cert_revoked, mock_cleanup
+        self, mock_get_hostname, mock_update_ingress, mock_cert_revoked, mock_cleanup
     ):
         """
         arrange: given the harnessed charm with all relations set and no juju secrets
         act: when the on_certificate_invalidated method is executed with a revoked cert
         assert: the method is executed properly, calling _on_certificate_revoked
         """
+        mock_get_hostname.return_value = "whatever"
         self.harness.set_leader(True)
         self.harness.add_relation("certificates", "certificates")
         event = CertificateInvalidatedEvent(
@@ -617,6 +619,7 @@ class TestCertificatesRelation(unittest.TestCase):
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("tls_relation.TLSRelationService.get_relation_data_field")
+    @patch("tls_relation.TLSRelationService.get_hostname_from_cert")
     @patch("tls_relation.generate_csr")
     @patch("ops.JujuVersion.has_secrets")
     @patch("ops.model.Model.get_secret")
@@ -625,6 +628,7 @@ class TestCertificatesRelation(unittest.TestCase):
         mock_get_secret,
         mock_has_secrets,
         mock_gen_csr,
+        mock_get_hostname,
         mock_get_data,
         mock_ingress_update,
         mock_cert_renewal,
@@ -636,6 +640,7 @@ class TestCertificatesRelation(unittest.TestCase):
         """
         mock_has_secrets.return_value = True
         mock_get_data.return_value = "whatever"
+        mock_get_hostname.return_value = "whatever"
         mock_gen_csr.return_value = b"csr"
         self.harness.set_leader(True)
         self.harness.disable_hooks()
@@ -659,9 +664,15 @@ class TestCertificatesRelation(unittest.TestCase):
     )
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("tls_relation.TLSRelationService.get_relation_data_field")
+    @patch("tls_relation.TLSRelationService.get_hostname_from_cert")
     @patch("tls_relation.generate_csr")
     def test_certificate_expiring_no_secrets(
-        self, mock_gen_csr, mock_get_data, mock_ingress_update, mock_cert_renewal
+        self,
+        mock_gen_csr,
+        mock_get_hostname,
+        mock_get_data,
+        mock_ingress_update,
+        mock_cert_renewal,
     ):
         """
         arrange: given the harnessed charm with all relations set and no juju secrets
@@ -669,6 +680,7 @@ class TestCertificatesRelation(unittest.TestCase):
         assert: the method is executed properly
         """
         mock_get_data.return_value = "whatever"
+        mock_get_hostname.return_value = "whatever"
         mock_gen_csr.return_value = b"csr"
         self.harness.set_leader(True)
         self.set_up_all_relations()
@@ -747,9 +759,10 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("tls_relation.TLSRelationService.generate_password")
     @patch("tls_relation.generate_csr")
     @patch("tls_relation.TLSRelationService.get_relation_data_field")
+    @patch("tls_relation.TLSRelationService.get_hostname_from_cert")
     @patch("charm.NginxIngressCharm._update_ingress")
     def test_certificate_available_no_secrets(
-        self, mock_update, mock_get_data, mock_gen_csr, mock_gen_pass
+        self, mock_update, mock_get_hostname, mock_get_data, mock_gen_csr, mock_gen_pass
     ):
         """
         arrange: given the harnessed charm with all relations set and no juju secrets
@@ -759,6 +772,7 @@ class TestCertificatesRelation(unittest.TestCase):
         mock_gen_csr.return_value = b"csr"
         mock_gen_pass.return_value = "123456789101"
         mock_get_data.return_value = "whatever"
+        mock_get_hostname.return_value = "whatever"
         self.harness.set_leader(True)
         self.set_up_all_relations()
         event = CertificateAvailableEvent(
@@ -771,6 +785,7 @@ class TestCertificatesRelation(unittest.TestCase):
     @patch("tls_relation.TLSRelationService.generate_password")
     @patch("tls_relation.generate_csr")
     @patch("tls_relation.TLSRelationService.get_relation_data_field")
+    @patch("tls_relation.TLSRelationService.get_hostname_from_cert")
     @patch("charm.NginxIngressCharm._update_ingress")
     @patch("ops.JujuVersion.has_secrets")
     @patch("ops.model.Model.get_secret")
@@ -779,6 +794,7 @@ class TestCertificatesRelation(unittest.TestCase):
         mock_get_secret,
         mock_has_secrets,
         mock_update,
+        mock_get_hostname,
         mock_get_data,
         mock_gen_csr,
         mock_gen_pass,
@@ -791,6 +807,7 @@ class TestCertificatesRelation(unittest.TestCase):
         mock_gen_csr.return_value = b"csr"
         mock_gen_pass.return_value = "123456789101"
         mock_get_data.return_value = "whatever"
+        mock_get_hostname.return_value = "whatever"
         mock_has_secrets.return_value = True
         self.harness.set_leader(True)
         self.harness.disable_hooks()


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Upgrade the TLS Certificates library to v3. Also inject the full chain in the K8S secret instead of only the certificates.

### Rationale

When a certificates uses intermediate certificate the chain be stored in the secret for Nginx to provide a valid certificate chain to the user

### Juju Events Changes

N/A

### Module Changes

Due to some event changed, I had to adapt the `get_hostname_from_csr` to `get_hostname_from_cert` as CSR wasn't available anymore in some events.

### Library Changes

Upgraded TLS Certificate library

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)