### PR TITLE
Handle the ingress-relation-broken event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -544,7 +544,17 @@ class NginxIngressCharm(CharmBase):
         if tls_relation:
             tls_relation.data[self.app].clear()
         if JujuVersion.from_environ().has_secrets:
-            hostnames = self.get_all_hostnames()
+            try:
+                hostnames = self.get_all_hostnames()
+            except InvalidIngressError as e:
+                LOGGER.warning("InvalidIngressError: %s", e)
+                LOGGER.warning((
+                    "Certificates relation removed so our ingress definition may be "
+                    "invalid. Just ignore, since we're likely removing the charm or "
+                    "the entire model, in which case Juju will clean up the relevant "
+                    "k8s resources."
+                ))
+                return
             for hostname in hostnames:
                 try:
                     secret = self.model.get_secret(label=f"private-key-{hostname}")


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Correctly handle the ingress-relation-broken event (for instance in case of destroying a model).

### Rationale

Currently if you have an ingress relation and try to destroy the model we're trying to run `get_all_hostnames` but it's failing with an `InvalidIngressError`.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->