### PR TITLE
Initialise tls certificate from relation data

### DIFF
--- a/src/tls_relation.py
+++ b/src/tls_relation.py
@@ -38,6 +38,18 @@ class TLSRelationService:
         self.keys: Dict[Union[str, None], Union[str, None]] = {}
         self.charm_model = model
         self.charm_app = model.app
+        self._init_certs_and_keys()
+
+    def _init_certs_and_keys(self) -> None:
+        """Initialize the certificates and keys which are already present in relation data."""
+        tls_certificates_relation = self.get_tls_relation()
+        if not tls_certificates_relation:
+            return
+        for key, value in tls_certificates_relation.data[self.charm_app].items():
+            if key.startswith("chain-"):
+                hostname = key.split("-", maxsplit=1)[1]
+                self.certs[hostname] = value
+                self.keys[hostname] = self._get_private_key(hostname)["key"]
 
     def generate_password(self) -> str:
         """Generate a random 12 character password.


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Initialise tls certificate data from relation data.

### Rationale

Currently, when an ingress-relation-changed or a upgrade-charm hook is executed, the event does not contain a certificate and so the reconciliation removes it. This PR fixes this by loading the data from the relation.

Fixes 
- https://github.com/canonical/nginx-ingress-integrator-operator/issues/137
- https://github.com/canonical/nginx-ingress-integrator-operator/issues/138


### Juju Events Changes

n/a

### Module Changes

`tls_relation.TLSRelationService.__init__`: initialise the dicts certs and keys from relation data

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

repo is not yet setup for src-docs
<!-- Explanation for any unchecked items above -->