### PR TITLE
use dict.get() to fetch cert

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -399,7 +399,7 @@ class NginxIngressCharm(CharmBase):
             event.fail("Certificates relation not created.")
             return
         tls_rel_data = tls_certificates_relation.data[self.app]
-        if tls_rel_data[f"certificate-{hostname}"]:
+        if tls_rel_data.get(f"certificate-{hostname}"):
             event.set_results(
                 {
                     f"certificate-{hostname}": tls_rel_data[f"certificate-{hostname}"],


### PR DESCRIPTION
not using `get()` will result in KeyError being raised if no certificate is found for the required hostname, masking the intended fail message.

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->