### PR TITLE
Add check for remote units before considering ingress relation ready

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,5 +8,4 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -153,15 +153,15 @@ class NginxIngressCharm(CharmBase):
         """Get the current effective relation.
 
         Returns:
-            The current effective relation object, None if there are no relation.
+            The current effective relation object, None if there is no relation or it is not ready.
         """
         if self.model.get_relation("nginx-route") is not None:
             relation = cast(Relation, self.model.get_relation("nginx-route"))
-            if relation.app is not None and relation.data[relation.app]:
+            if relation.app is not None and relation.data[relation.app] and relation.units:
                 return relation
         elif self.model.get_relation("ingress") is not None:
             relation = cast(Relation, self.model.get_relation("ingress"))
-            if relation.app is not None and relation.data[relation.app]:
+            if relation.app is not None and relation.data[relation.app] and relation.units:
                 return relation
         return None
 
@@ -433,14 +433,7 @@ class NginxIngressCharm(CharmBase):
         """
         if self._check_tls_nginx_relations(event):
             return
-        try:
-            hostnames = self.get_all_hostnames()
-        except InvalidIngressError as exc:
-            LOGGER.warning(
-                "Ingress relation seems not to be ready yet, will defer the event: %s", exc
-            )
-            event.defer()
-            return
+        hostnames = self.get_all_hostnames()
         for hostname in hostnames:
             self._tls.certificate_relation_created(hostname)
 
@@ -452,14 +445,7 @@ class NginxIngressCharm(CharmBase):
         """
         if self._check_tls_nginx_relations(event):
             return
-        try:
-            hostnames = self.get_all_hostnames()
-        except InvalidIngressError as exc:
-            LOGGER.warning(
-                "Ingress relation seems not to be ready yet, will defer the event: %s", exc
-            )
-            event.defer()
-            return
+        hostnames = self.get_all_hostnames()
         for hostname in hostnames:
             self._tls.certificate_relation_joined(hostname, self.certificates)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -433,7 +433,14 @@ class NginxIngressCharm(CharmBase):
         """
         if self._check_tls_nginx_relations(event):
             return
-        hostnames = self.get_all_hostnames()
+        try:
+            hostnames = self.get_all_hostnames()
+        except InvalidIngressError as exc:
+            LOGGER.warning(
+                "Ingress relation seems not to be ready yet, will defer the event: %s", exc
+            )
+            event.defer()
+            return
         for hostname in hostnames:
             self._tls.certificate_relation_created(hostname)
 
@@ -445,7 +452,14 @@ class NginxIngressCharm(CharmBase):
         """
         if self._check_tls_nginx_relations(event):
             return
-        hostnames = self.get_all_hostnames()
+        try:
+            hostnames = self.get_all_hostnames()
+        except InvalidIngressError as exc:
+            LOGGER.warning(
+                "Ingress relation seems not to be ready yet, will defer the event: %s", exc
+            )
+            event.defer()
+            return
         for hostname in hostnames:
             self._tls.certificate_relation_joined(hostname, self.certificates)
 

--- a/tests/unit/test_cert_relation.py
+++ b/tests/unit/test_cert_relation.py
@@ -23,7 +23,6 @@ from ops.testing import Harness
 
 from charm import NginxIngressCharm
 from controller.secret import SecretController
-from exceptions import InvalidIngressError
 from tests.unit.constants import TEST_NAMESPACE
 from tls_relation import TLSRelationService
 
@@ -183,43 +182,6 @@ class TestCertificatesRelation(unittest.TestCase):
         mock_has_secrets.return_value = True
         mock_get_secret.side_effect = SecretNotFoundError
         self.harness.charm._on_certificates_relation_created(event)
-        mock_create_cert.assert_not_called()
-        mock_gen_csr.assert_not_called()
-
-    @pytest.mark.usefixtures("patch_load_incluster_config")
-    @patch("tls_relation.TLSRelationService.get_relation_data_field")
-    @patch("tls_relation.generate_csr")
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates"
-        ".TLSCertificatesRequiresV3.request_certificate_creation"
-    )
-    @patch("charm.NginxIngressCharm._update_ingress")
-    @patch("charm.NginxIngressCharm.get_all_hostnames")
-    @patch("ops.model.Model.get_secret")
-    @patch("ops.JujuVersion.has_secrets")
-    def test_certificate_relation_created_joined_ingress_not_ready(
-        self,
-        mock_has_secrets,
-        mock_get_secret,
-        mock_get_hostnames,
-        mock_ingress_update,
-        mock_create_cert,
-        mock_gen_csr,
-        mock_get_data,
-    ):
-        mock_get_data.return_value = "whatever"
-        mock_gen_csr.return_value = b"csr"
-        event = RelationCreatedEvent(relation=None, handle=None)
-        self.harness.set_leader(True)
-        self.harness.disable_hooks()
-        self.set_up_all_relations()
-        self.harness.enable_hooks()
-        mock_get_hostnames.side_effect = InvalidIngressError("not ready yet")
-        self.harness.charm._on_certificates_relation_created(event)
-        mock_create_cert.assert_not_called()
-        mock_gen_csr.assert_not_called()
-
-        self.harness.charm._on_certificates_relation_joined(event)
         mock_create_cert.assert_not_called()
         mock_gen_csr.assert_not_called()
 


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Check that charm can see remote units of the ingress relationship before proceeding.


### Rationale

Fix #140 

If you deploy tls at the same time as ingress (e.g. using the terraform provider), nginx-ingress will fail in the `certificates-relation-created` hook and not recover.

The reason is explained in https://github.com/canonical/nginx-ingress-integrator-operator/issues/140#issuecomment-2133931059, that certificates-relation-created is fired before ingress-relation-joined, and the charm sees no units in the relation, causing an error in `ingress_definition.IngressDefinitionEssence.upstream_endpoints`:

```
unit-nginx-ingress-integrator-0: 13:59:56 ERROR unit.nginx-ingress-integrator/0.juju-log certificates:51: Uncaught exception while in charm code:
Traceback (most recent call last):
  File "./src/charm.py", line 557, in <module>
    main(NginxIngressCharm)
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/venv/ops/main.py", line 544, in main
    manager.run()
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/venv/ops/main.py", line 520, in run
    self._emit()
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/venv/ops/main.py", line 509, in _emit
    _emit_charm_event(self.charm, self.dispatcher.event_name)
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/venv/ops/main.py", line 143, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/venv/ops/framework.py", line 350, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/venv/ops/framework.py", line 849, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/venv/ops/framework.py", line 939, in _reemit
    custom_handler(event)
  File "./src/charm.py", line 436, in _on_certificates_relation_created
    hostnames = self.get_additional_hostnames()
  File "./src/charm.py", line 423, in get_additional_hostnames
    definition = self._get_definition_from_relation(relation)  # type: ignore[arg-type]
  File "./src/charm.py", line 199, in _get_definition_from_relation
    ingress_definition = IngressDefinition.from_essence(definition_essence)
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/src/ingress_definition.py", line 595, in from_essence
    upstream_endpoint_type=essence.upstream_endpoint_type,
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/src/ingress_definition.py", line 489, in upstream_endpoint_type
    if not self.upstream_endpoints:
  File "/var/lib/juju/agents/unit-nginx-ingress-integrator-0/charm/src/ingress_definition.py", line 465, in upstream_endpoints
    raise InvalidIngressError("no endpoints are provided in ingress relation")
exceptions.InvalidIngressError: no endpoints are provided in ingress relation
unit-nginx-ingress-integrator-0: 13:59:56 ERROR juju.worker.uniter.operation hook "certificates-relation-created" (via hook dispatching script: dispatch) failed: exit status 1
```

### Juju Events Changes

n/a

### Module Changes

charm.NginxIngressCharm._get_nginx_relation: Add non-empty check for `relation.units`

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->