### PR TITLE
Fix ingress resource listing in the `tls_relation` module

### DIFF
--- a/src/tls_relation.py
+++ b/src/tls_relation.py
@@ -80,7 +80,7 @@ class TLSRelationService:
         if tls_certificates_relation:
             api = kubernetes.client.NetworkingV1Api()
             ingresses = api.list_namespaced_ingress(
-                namespace=namespace, selector=f"{CREATED_BY_LABEL}={self.charm_app.name}"
+                namespace=namespace, label_selector=f"{CREATED_BY_LABEL}={self.charm_app.name}"
             )
             hostnames_to_revoke = []
             hostnames_unchanged = []

--- a/src/tls_relation.py
+++ b/src/tls_relation.py
@@ -22,7 +22,7 @@ from cryptography.x509.oid import NameOID
 from ops.jujuversion import JujuVersion
 from ops.model import Model, Relation, SecretNotFoundError
 
-from consts import PEER_RELATION_NAME, TLS_CERT
+from consts import CREATED_BY_LABEL, PEER_RELATION_NAME, TLS_CERT
 
 
 class TLSRelationService:
@@ -79,7 +79,9 @@ class TLSRelationService:
         hostnames_to_revoke: List[str] = []
         if tls_certificates_relation:
             api = kubernetes.client.NetworkingV1Api()
-            ingresses = api.list_namespaced_ingress(namespace=namespace)
+            ingresses = api.list_namespaced_ingress(
+                namespace=namespace, selector=f"{CREATED_BY_LABEL}={self.charm_app.name}"
+            )
             hostnames_to_revoke = []
             hostnames_unchanged = []
             for hostname in hostnames:


### PR DESCRIPTION
The current implementation of the `tls_relation` module, when lists all ingress resources created by the charm, doesn't specify a label selector. As a result, it includes ingress resources that are not managed by this charm.

This pull request addresses the issue using a very straightforward solution: adding a label selector to the `list_namespaced_ingress` call within the `tls_relation` module, so that only the ingress resources managed by this charm are selected.