### PR TITLE
fix: remove unsupported arch

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -24,11 +24,14 @@ bases:
       - arm64
 parts:
   charm:
+    build-snaps:
+      - rustup
+    override-build: |
+      rustup default stable
+      craftctl default
     build-packages:
       - build-essential
       - python3-dev
       - pkg-config
       - libffi-dev
       - libssl-dev
-      - rustc
-      - cargo

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,12 +5,23 @@ bases:
   - build-on:
     - name: "ubuntu"
       channel: "20.04"
+      architecrtures:
+      - amd64
     run-on:
     - name: "ubuntu"
       channel: "20.04"
       architectures:
-        - amd64
-        - arm64
+      - amd64
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+      architecrtures:
+      - arm64
+    run-on:
+    - name: "ubuntu"
+      channel: "20.04"
+      architectures:
+      - arm64
 parts:
   charm:
     build-packages:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -5,7 +5,7 @@ bases:
   - build-on:
     - name: "ubuntu"
       channel: "20.04"
-      architecrtures:
+      architectures:
       - amd64
     run-on:
     - name: "ubuntu"
@@ -15,7 +15,7 @@ bases:
   - build-on:
     - name: "ubuntu"
       channel: "20.04"
-      architecrtures:
+      architectures:
       - arm64
     run-on:
     - name: "ubuntu"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,7 +10,6 @@ bases:
       channel: "20.04"
       architectures:
         - amd64
-        - aarch64
         - arm64
 parts:
   charm:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

According to https://juju.is/docs/sdk/charmcraft-yaml, aarch64 is not one of the archs that is supported. arm64 is though!
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->