### PR TITLE
Catch KeyError when calling get_relation_data_field

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -487,11 +487,12 @@ class NginxIngressCharm(CharmBase):
             return
         tls_certificates_relation = self._tls.get_tls_relation()
         for hostname in revoke_list:
-            old_csr = self._tls.get_relation_data_field(
-                f"csr-{hostname}",
-                tls_certificates_relation,  # type: ignore[arg-type]
-            )
-            if not old_csr:
+            try:
+                old_csr = self._tls.get_relation_data_field(
+                    f"csr-{hostname}",
+                    tls_certificates_relation,  # type: ignore[arg-type]
+                )
+            except KeyError:
                 continue
             if JujuVersion.from_environ().has_secrets:
                 try:


### PR DESCRIPTION
The `TLSRelationService.get_relation_data_field` will raise a `KeyError` instead of returning `None` when the requested data field is not found. Fix the place in `charm.py` where `TLSRelationService.get_relation_data_field` is called to catch the `KeyError` instead of checking if the return value is `None`.