### PR TITLE
Publish also arm64 architecture

### DIFF
--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -11,5 +11,5 @@ jobs:
       channel: 1.28-strict/stable
       modules: '["test_cert_relation", "test_ingress_relation", "test_nginx_route"]'
       juju-channel: 3.1/stable
+      self-hosted-runner: true
       self-hosted-runner-arch: arm64
-

--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  integration-tests:
+  integration-tests-arm64:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:

--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -13,5 +13,6 @@ jobs:
       juju-channel: 3.1/stable
       self-hosted-runner: true
       self-hosted-runner-arch: arm64
+      self-hosted-runner-label: "edge"
       builder-runner-label: arm64
       extra-arguments: -x --model-arch=arm64

--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -14,3 +14,4 @@ jobs:
       self-hosted-runner: true
       self-hosted-runner-arch: arm64
       builder-runner-label: arm64
+      extra-arguments: -x --model-arch=arm64

--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -1,0 +1,15 @@
+name: Integration tests
+
+on:
+  pull_request:
+
+jobs:
+  integration-tests:
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
+    secrets: inherit
+    with:
+      channel: 1.28-strict/stable
+      modules: '["test_cert_relation", "test_ingress_relation", "test_nginx_route"]'
+      juju-channel: 3.1/stable
+      self-hosted-runner-arch: arm64
+

--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -1,4 +1,4 @@
-name: Integration tests
+name: Integration tests arm64
 
 on:
   pull_request:

--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -13,3 +13,4 @@ jobs:
       juju-channel: 3.1/stable
       self-hosted-runner: true
       self-hosted-runner-arch: arm64
+      builder-runner-label: arm64

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -1,4 +1,4 @@
-name: Publish to edge arm64
+name: Publish to edge
 
 on:
   push:
@@ -7,6 +7,6 @@ on:
       - track/*
 
 jobs:
-  publish-to-edge-arm64:
+  publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit

--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -1,4 +1,4 @@
-name: Publish to edge
+name: Publish to edge arm64
 
 on:
   push:
@@ -7,6 +7,6 @@ on:
       - track/*
 
 jobs:
-  publish-to-edge:
+  publish-to-edge-arm64:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     secrets: inherit

--- a/.github/workflows/publish_charm_arm64.yaml
+++ b/.github/workflows/publish_charm_arm64.yaml
@@ -1,0 +1,13 @@
+name: Publish to edge
+
+on:
+  push:
+    branches:
+      - main
+      - track/*
+
+jobs:
+  publish-to-edge:
+    uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    integration-test-workflow-file: "integration_test_arm64.yaml"
+    secrets: inherit

--- a/.github/workflows/publish_charm_arm64.yaml
+++ b/.github/workflows/publish_charm_arm64.yaml
@@ -1,4 +1,4 @@
-name: Publish to edge
+name: Publish to edge arm64
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
       - track/*
 
 jobs:
-  publish-to-edge:
+  publish-to-edge-arm64:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
     integration-test-workflow-file: "integration_test_arm64.yaml"
     secrets: inherit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,4 @@ def pytest_addoption(parser):
         parser: Pytest parser.
     """
     parser.addoption("--charm-file", action="store")
+    parser.addoption("--model-arch", action="store")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ import pytest_asyncio
 import yaml
 from juju.model import Model
 from ops.model import ActiveStatus
-from pytest import fixture, Config
+from pytest import Config, fixture
 from pytest_operator.plugin import OpsTest
 
 # Mype can't recognize the name as a string type, so we should skip the type check.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -42,7 +42,7 @@ async def model_fixture(ops_test: OpsTest, pytestconfig: Config) -> Model:
     assert ops_test.model
     model_arch = pytestconfig.getoption("--model-arch")
     if model_arch:
-        #  Equivalent to `juju set-model-constraints arch=arm64`
+        #  Equivalent to `juju set-model-constraints arch=<amd64 / arm64 / ...>`
         await ops_test.model.set_constraints({"arch": model_arch})
     return ops_test.model
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,7 +12,7 @@ import pytest_asyncio
 import yaml
 from juju.model import Model
 from ops.model import ActiveStatus
-from pytest import fixture
+from pytest import fixture, Config
 from pytest_operator.plugin import OpsTest
 
 # Mype can't recognize the name as a string type, so we should skip the type check.
@@ -36,10 +36,14 @@ def app_name(metadata):
     yield metadata["name"]
 
 
-@pytest_asyncio.fixture(scope="module", name="model")
-async def model_fixture(ops_test: OpsTest) -> Model:
+@pytest_asyncio.fixture(scope="module", name="model", autouse=True)
+async def model_fixture(ops_test: OpsTest, pytestconfig: Config) -> Model:
     """The current test model."""
     assert ops_test.model
+    model_arch = pytestconfig.getoption("--model-arch")
+    if model_arch:
+        #  Equivalent to `juju set-model-constraints arch=arm64`
+        await ops_test.model.set_constraints({"arch": model_arch})
     return ops_test.model
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,7 @@ deps =
     protobuf==3.20.3
     pydantic
     pytest
-    juju==3.1.2.0
+    juju==3.2.3.0
     pytest-operator
     pytest-asyncio
     kubernetes


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

We want to build and publish an arm64 charm for the `nginx-integrator`.


For the integration tests to work, an arm64 version of `any-charm` is needed. Added in https://github.com/canonical/any-charm/pull/23


### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->