### PR TITLE
Fix arm64 publish

### DIFF
--- a/.github/workflows/publish_charm_arm64.yaml
+++ b/.github/workflows/publish_charm_arm64.yaml
@@ -9,5 +9,7 @@ on:
 jobs:
   publish-to-edge-arm64:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
-    integration-test-workflow-file: "integration_test_arm64.yaml"
     secrets: inherit
+    with:
+      integration-test-workflow-file: "integration_test_arm64.yaml"
+


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

The input variable `integration-test-workflow-file` was not after a `with:`.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->