### PR TITLE
Add the `proxy-send-timeout` and `proxy-connect-timeout` options

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,4 +10,4 @@ jobs:
     with:
       channel: 1.28-strict/stable
       modules: '["test_cert_relation", "test_ingress_relation", "test_nginx_route"]'
-      juju-channel: 3.1/stable
+      juju-channel: 3.6/stable

--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -10,7 +10,7 @@ jobs:
     with:
       channel: 1.28-strict/stable
       modules: '["test_cert_relation", "test_ingress_relation", "test_nginx_route"]'
-      juju-channel: 3.1/stable
+      juju-channel: 3.6/stable
       self-hosted-runner: true
       self-hosted-runner-arch: arm64
       self-hosted-runner-label: "edge"

--- a/config.yaml
+++ b/config.yaml
@@ -82,6 +82,14 @@ options:
     default: 60
     description: Defines a timeout in seconds for reading a response from the proxied server.
     type: int
+  proxy-send-timeout:
+    default: 60
+    description: Defines a timeout in seconds for sending a response from the proxied server.
+    type: int
+  proxy-connect-timeout:
+    default: 60
+    description: Defines a timeout in seconds for connecting to the proxied server.
+    type: int
   retry-errors:
     default: ""
     description: |

--- a/config.yaml
+++ b/config.yaml
@@ -88,7 +88,7 @@ options:
     type: int
   proxy-connect-timeout:
     default: 60
-    description: Defines a timeout in seconds for connecting to the proxied server.
+    description: Timeout in seconds for connecting to the proxied server.
     type: int
   retry-errors:
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -80,11 +80,11 @@ options:
     type: string
   proxy-read-timeout:
     default: 60
-    description: Defines a timeout in seconds for reading a response from the proxied server.
+    description: Timeout in seconds for reading a response from the proxied server.
     type: int
   proxy-send-timeout:
     default: 60
-    description: Defines a timeout in seconds for sending a response from the proxied server.
+    description: Timeout in seconds for sending a response from the proxied server.
     type: int
   proxy-connect-timeout:
     default: 60

--- a/src/controller/ingress.py
+++ b/src/controller/ingress.py
@@ -139,6 +139,8 @@ class IngressController(
         annotations = {
             "nginx.ingress.kubernetes.io/proxy-body-size": definition.max_body_size,
             "nginx.ingress.kubernetes.io/proxy-read-timeout": definition.proxy_read_timeout,
+            "nginx.ingress.kubernetes.io/proxy-send-timeout": definition.proxy_send_timeout,
+            "nginx.ingress.kubernetes.io/proxy-connect-timeout": definition.proxy_connect_timeout,
             "nginx.ingress.kubernetes.io/backend-protocol": definition.backend_protocol,
         }
         if not definition.enable_access_log:

--- a/src/ingress_definition.py
+++ b/src/ingress_definition.py
@@ -286,8 +286,17 @@ class IngressDefinitionEssence:  # pylint: disable=too-many-public-methods
     @property
     def proxy_read_timeout(self) -> str:
         """Return the proxy-read-timeout to use for k8s ingress."""
-        proxy_read_timeout = self._get_config_or_relation_data("proxy-read-timeout", 60)
-        return f"{proxy_read_timeout}"
+        return str(self._get_config_or_relation_data("proxy-read-timeout", 60))
+
+    @property
+    def proxy_send_timeout(self) -> str:
+        """Return the proxy-send-timeout to use for k8s ingress."""
+        return str(self._get_config_or_relation_data("proxy-send-timeout", 60))
+
+    @property
+    def proxy_connect_timeout(self) -> str:
+        """Return the proxy-connect-timeout to use for k8s ingress."""
+        return str(self._get_config_or_relation_data("proxy-connect-timeout", 5))
 
     @property
     def rewrite_enabled(self) -> bool:
@@ -536,6 +545,8 @@ class IngressDefinition:  # pylint: disable=too-many-public-methods,too-many-ins
     owasp_modsecurity_custom_rules: str
     path_routes: List[str]
     proxy_read_timeout: str
+    proxy_send_timeout: str
+    proxy_connect_timeout: str
     retry_errors: str
     rewrite_enabled: bool
     rewrite_target: str
@@ -581,6 +592,8 @@ class IngressDefinition:  # pylint: disable=too-many-public-methods,too-many-ins
             owasp_modsecurity_custom_rules=essence.owasp_modsecurity_custom_rules,
             path_routes=essence.path_routes,
             proxy_read_timeout=essence.proxy_read_timeout,
+            proxy_send_timeout=essence.proxy_send_timeout,
+            proxy_connect_timeout=essence.proxy_connect_timeout,
             retry_errors=essence.retry_errors,
             rewrite_enabled=essence.rewrite_enabled,
             rewrite_target=essence.rewrite_target,

--- a/tests/unit/test_cert_relation.py
+++ b/tests/unit/test_cert_relation.py
@@ -124,7 +124,7 @@ class TestCertificatesRelation(unittest.TestCase):
     def test_generate_password(self):
         tls_rel = TLSRelationService(self.harness.charm.model)
         password = tls_rel.generate_password()
-        assert type(password) == str
+        assert isinstance(password, str)
         assert len(password) == 12
 
     @patch("tls_relation.TLSRelationService.update_relation_data_fields")
@@ -1116,7 +1116,7 @@ class TestCertificatesRelation(unittest.TestCase):
         domains = ["domain1", "domain2"]
         test_file_path = os.path.join(os.getcwd(), "tests", "files")
         encrypted_private_keys = [
-            open(os.path.join(test_file_path, f"test_encrypted_private_key{i+1}.pem")).read()
+            open(os.path.join(test_file_path, f"test_encrypted_private_key{i + 1}.pem")).read()
             for i in range(len(domains))
         ]
 
@@ -1135,7 +1135,7 @@ class TestCertificatesRelation(unittest.TestCase):
         assert len(decrypted_private_keys) == len(domains)
 
         decrypted_private_keys_from_disk = {
-            domains[i]: open(os.path.join(test_file_path, f"test_private_key{i+1}.pem")).read()
+            domains[i]: open(os.path.join(test_file_path, f"test_private_key{i + 1}.pem")).read()
             for i in range(len(domains))
         }
 

--- a/tox.ini
+++ b/tox.ini
@@ -107,11 +107,10 @@ deps =
     protobuf==3.20.3
     pydantic
     pytest
-    juju==3.2.3.0
+    juju==3.6.0.0
     pytest-operator
     pytest-asyncio
     kubernetes
-    websockets<14.0 # https://github.com/juju/python-libjuju/issues/1184
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,7 @@ deps =
     pytest-operator
     pytest-asyncio
     kubernetes
+    websockets<14.0 # https://github.com/juju/python-libjuju/issues/1184
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -36,18 +36,19 @@ description = Check code against coding style standards
 deps =
     black
     codespell
-    flake8<6.0.0
+    flake8
     flake8-builtins
-    flake8-copyright<6.0.0
+    flake8-copyright
     flake8-docstrings>=1.6.0
     flake8-docstrings-complete>=1.0.3
     flake8-test-docs>=1.0
     isort
-    mypy==1.6.1
+    mypy
+    ops-scenario
     pep8-naming
     pydocstyle>=2.10
     pylint
-    pyproject-flake8<6.0.0
+    pyproject-flake8
     pytest
     pytest-asyncio
     pytest-operator


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add the `proxy-send-timeout` and `proxy-connect-timeout` charm configurations to adjust the ingress timeout.

The default values are taken from the corresponding NGINX configuration defaults.
https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_send_timeout
https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_connect_timeout

Fix: https://github.com/canonical/nginx-ingress-integrator-operator/issues/164

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->