### PR TITLE
Provide more specific blocked status msg to indicate missing IP

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -336,6 +336,7 @@ class NginxIngressCharm(CharmBase):
 
             self.unit.status = ActiveStatus(message)
         except InvalidIngressError as exc:
+            LOGGER.exception("Invalid ingress definition")
             self.unit.status = BlockedStatus(exc.msg)
 
     def _generate_ingress_url(self, hostname: str, pathroutes: List[str]) -> Optional[str]:

--- a/src/ingress_definition.py
+++ b/src/ingress_definition.py
@@ -5,6 +5,7 @@
 
 import dataclasses
 import ipaddress
+import logging
 import re
 from typing import List, Optional, Union, cast
 
@@ -14,6 +15,8 @@ from ops.model import Application, ConfigData, Model, Relation
 
 from consts import BOOLEAN_CONFIG_FIELDS
 from exceptions import InvalidIngressError
+
+logger = logging.getLogger(__name__)
 
 
 class IngressDefinitionEssence:  # pylint: disable=too-many-public-methods
@@ -452,17 +455,21 @@ class IngressDefinitionEssence:  # pylint: disable=too-many-public-methods
         endpoints = []
         if self.use_endpoint_slice:
             try:
-                endpoints = [
-                    u.ip
-                    for u in cast(IngressPerAppProvider, self.ingress_provider)
+                for u in (
+                    cast(IngressPerAppProvider, self.ingress_provider)
                     .get_data(self.relation)
                     .units
-                    if u.ip is not None
-                ]
+                ):
+                    if u.ip is not None:
+                        endpoints.append(u.ip)
+                    else:
+                        logger.error(
+                            "unit with hostname %s has no ip address in relation data", u.host
+                        )
             except DataValidationError as exc:
                 raise InvalidIngressError(msg=f"{exc}, cause: {exc.__cause__!r}") from exc
         if self.use_endpoint_slice and not endpoints:
-            raise InvalidIngressError("no endpoints are provided in ingress relation")
+            raise InvalidIngressError("no endpoints with ip are provided in ingress relation")
         return endpoints
 
     @property

--- a/src/ingress_definition.py
+++ b/src/ingress_definition.py
@@ -460,12 +460,12 @@ class IngressDefinitionEssence:  # pylint: disable=too-many-public-methods
                     .get_data(self.relation)
                     .units
                 ):
-                    if u.ip is not None:
-                        endpoints.append(u.ip)
-                    else:
+                    if u.ip is None:
                         logger.error(
                             "unit with hostname %s has no ip address in relation data", u.host
                         )
+                        continue
+                    endpoints.append(u.ip)
             except DataValidationError as exc:
                 raise InvalidIngressError(msg=f"{exc}, cause: {exc.__cause__!r}") from exc
         if self.use_endpoint_slice and not endpoints:

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -64,7 +64,7 @@ TEST_INCOMPLETE_INGRESS_PARAMS = [
     pytest.param(["port"], "waiting", "waiting for relation", id="missing-port"),
     pytest.param(["name"], "waiting", "waiting for relation", id="missing-name"),
     pytest.param(
-        ["ip"], "blocked", "no endpoints are provided in ingress relation", id="missing-ip"
+        ["ip"], "blocked", "no endpoints with ip are provided in ingress relation", id="missing-ip"
     ),
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -110,6 +110,7 @@ deps =
     pytest-operator
     pytest-asyncio
     kubernetes
+    websockets<14.0 # https://github.com/juju/python-libjuju/issues/1184
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
Applicable spec: n/a

### Overview

Provide more specific blocking status to indicate missing IP and log stack trace.

### Rationale

We had to troubleshoot a production issue where the ip was missing in the databag. The current blocked state was not so helpful, we saw relation data but did not spot the missing ip or were not aware that this is required. 
Providing a more specific blocked status message should help users of the charm.

### Juju Events Changes

n/a

### Module Changes

n/a

### Library Changes

n/a

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->