### PR TITLE
Use the full certificate chain from the tls-certificates relation for ingress

### DIFF
--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -13,6 +13,6 @@ jobs:
       juju-channel: 3.6/stable
       self-hosted-runner: true
       self-hosted-runner-arch: arm64
-      self-hosted-runner-label: "edge"
+      self-hosted-runner-label: "large"
       builder-runner-label: arm64
       extra-arguments: -x --model-arch=arm64

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -58,7 +58,7 @@ config:
       default: ""
       description: >-
         Indicates how NGINX should communicate with the backend service. Valid
-        Values: HTTP, HTTPS, GRPC, GRPCS, AJP and FCGI.
+        Values: HTTP, HTTPS, GRPC, GRPCS and FCGI.
       type: string
     enable-access-log:
       description: >-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 kubernetes==24.2.0 # last version with DiscoveryV1beta1Api
 ops==2.18.1
 jsonschema==4.23.0
-cryptography==44.0.2
+cryptography==45.0.0

--- a/src/charm.py
+++ b/src/charm.py
@@ -415,7 +415,7 @@ class NginxIngressCharm(CharmBase):
         )
         for provider_cert in provider_certs:
             hostname = provider_cert.certificate.common_name
-            certs[hostname] = "\n".join(provider_cert.chain)
+            certs[hostname] = "\n".join([cert.raw for cert in provider_cert.chain])
         return certs
 
     def _get_tls_keys(self) -> Dict[Union[str, None], Union[str, None]]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -415,7 +415,7 @@ class NginxIngressCharm(CharmBase):
         )
         for provider_cert in provider_certs:
             hostname = provider_cert.certificate.common_name
-            certs[hostname] = str(provider_cert.certificate)
+            certs[hostname] = str(provider_cert.chain)
         return certs
 
     def _get_tls_keys(self) -> Dict[Union[str, None], Union[str, None]]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -415,7 +415,7 @@ class NginxIngressCharm(CharmBase):
         )
         for provider_cert in provider_certs:
             hostname = provider_cert.certificate.common_name
-            certs[hostname] = str(provider_cert.chain)
+            certs[hostname] = "\n".join(provider_cert.chain)
         return certs
 
     def _get_tls_keys(self) -> Dict[Union[str, None], Union[str, None]]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -415,7 +415,7 @@ class NginxIngressCharm(CharmBase):
         )
         for provider_cert in provider_certs:
             hostname = provider_cert.certificate.common_name
-            certs[hostname] = "\n".join([cert.raw for cert in provider_cert.chain])
+            certs[hostname] = "\n".join(reversed([cert.raw for cert in provider_cert.chain]))
         return certs
 
     def _get_tls_keys(self) -> Dict[Union[str, None], Union[str, None]]:

--- a/src/charm.py
+++ b/src/charm.py
@@ -415,7 +415,13 @@ class NginxIngressCharm(CharmBase):
         )
         for provider_cert in provider_certs:
             hostname = provider_cert.certificate.common_name
-            certs[hostname] = "\n".join(reversed([cert.raw for cert in provider_cert.chain]))
+            chain_reversed = (
+                provider_cert.chain[-1].raw.strip() == provider_cert.certificate.raw.strip()
+            )
+            chain = [cert.raw for cert in provider_cert.chain]
+            if chain_reversed:
+                chain.reverse()
+            certs[hostname] = "\n\n".join(chain)
         return certs
 
     def _get_tls_keys(self) -> Dict[Union[str, None], Union[str, None]]:

--- a/src/ingress_definition.py
+++ b/src/ingress_definition.py
@@ -208,10 +208,10 @@ class IngressDefinitionEssence:  # pylint: disable=too-many-public-methods
         backend_protocol = cast(
             str, self._get_config_or_relation_data("backend-protocol", "HTTP")
         ).upper()
-        if backend_protocol not in ("HTTP", "HTTPS", "GRPC", "GRPCS", "AJP", "FCGI"):
+        if backend_protocol not in ("HTTP", "HTTPS", "GRPC", "GRPCS", "FCGI"):
             raise InvalidIngressError(
                 f"invalid backend protocol {backend_protocol!r}, "
-                f"valid values: HTTP, HTTPS, GRPC, GRPCS, AJP, FCGI"
+                f"valid values: HTTP, HTTPS, GRPC, GRPCS, FCGI"
             )
         return backend_protocol
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -151,7 +151,7 @@ async def build_and_deploy_ingress(model: Model, ops_test: OpsTest, pytestconfig
         pytestconfig: pytest config.
     """
 
-    async def _build_and_deploy_ingress():
+    async def _build_and_deploy_ingress(application_name: str = "ingress"):
         """Build and deploy the Ingress charm.
 
         Returns:
@@ -161,7 +161,7 @@ async def build_and_deploy_ingress(model: Model, ops_test: OpsTest, pytestconfig
         if not charm:
             charm = await ops_test.build_charm(".")
         return await model.deploy(
-            str(charm), application_name="ingress", series="jammy", trust=True
+            str(charm), application_name=application_name, series="jammy", trust=True
         )
 
     return _build_and_deploy_ingress

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,6 +8,7 @@
 from pathlib import Path
 
 import kubernetes
+import pytest
 import pytest_asyncio
 import yaml
 from juju.model import Model
@@ -141,7 +142,7 @@ async def wait_ingress_annotation(ops_test: OpsTest, get_ingress_annotation):
 
 
 @pytest_asyncio.fixture(scope="module")
-async def build_and_deploy_ingress(model: Model, ops_test: OpsTest):
+async def build_and_deploy_ingress(model: Model, ops_test: OpsTest, pytestconfig: pytest.Config):
     """Create an async function to build the nginx ingress integrator charm then deploy it.
 
     Args:
@@ -155,7 +156,9 @@ async def build_and_deploy_ingress(model: Model, ops_test: OpsTest):
         Returns:
             The fully deployed Ingress charm.
         """
-        charm = await ops_test.build_charm(".")
+        charm = pytestconfig.getoption("--charm-file")
+        if not charm:
+            charm = await ops_test.build_charm(".")
         return await model.deploy(
             str(charm), application_name="ingress", series="jammy", trust=True
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -148,6 +148,7 @@ async def build_and_deploy_ingress(model: Model, ops_test: OpsTest, pytestconfig
     Args:
         model: Juju model for the test.
         ops_test: Operator Framework for the test.
+        pytestconfig: pytest config.
     """
 
     async def _build_and_deploy_ingress():

--- a/tests/integration/test_cert_relation.py
+++ b/tests/integration/test_cert_relation.py
@@ -145,6 +145,7 @@ async def test_given_charms_deployed_when_relate_then_requirer_received_certs(
 async def test_given_additional_requirer_charm_deployed_when_relate_then_requirer_received_certs(
     model: Model,
     run_action,
+    build_and_deploy_ingress,
 ):
     """
     arrange: given charm has been built, deployed and integrated with a dependent application.
@@ -152,6 +153,7 @@ async def test_given_additional_requirer_charm_deployed_when_relate_then_require
     assert: the process of deployment, integration and certificate provision is successful.
     """
     new_requirer_app_name = "ingress2"
+    await build_and_deploy_ingress(application_name=new_requirer_app_name)
     await model.deploy(
         "any-charm",
         application_name=ANY_APP_NAME_2,

--- a/tests/integration/test_cert_relation.py
+++ b/tests/integration/test_cert_relation.py
@@ -93,7 +93,7 @@ async def build_and_deploy(
     await model.deploy(
         SELF_SIGNED_CERTIFICATES_CHARM_NAME,
         application_name=TLS_CERTIFICATES_PROVIDER_APP_NAME,
-        channel="edge",
+        channel="1/stable",
     )
 
     await model.wait_for_idle(

--- a/tests/integration/test_cert_relation.py
+++ b/tests/integration/test_cert_relation.py
@@ -93,7 +93,7 @@ async def build_and_deploy(
     await model.deploy(
         SELF_SIGNED_CERTIFICATES_CHARM_NAME,
         application_name=TLS_CERTIFICATES_PROVIDER_APP_NAME,
-        channel="beta",
+        channel="edge",
     )
 
     await model.wait_for_idle(

--- a/tests/integration/test_cert_relation.py
+++ b/tests/integration/test_cert_relation.py
@@ -144,7 +144,6 @@ async def test_given_charms_deployed_when_relate_then_requirer_received_certs(
 @pytest.mark.usefixtures("build_and_deploy")
 async def test_given_additional_requirer_charm_deployed_when_relate_then_requirer_received_certs(
     model: Model,
-    ops_test: OpsTest,
     run_action,
 ):
     """
@@ -153,10 +152,6 @@ async def test_given_additional_requirer_charm_deployed_when_relate_then_require
     assert: the process of deployment, integration and certificate provision is successful.
     """
     new_requirer_app_name = "ingress2"
-    charm = await ops_test.build_charm(".")
-    await model.deploy(
-        str(charm), application_name=new_requirer_app_name, series="jammy", trust=True
-    )
     await model.deploy(
         "any-charm",
         application_name=ANY_APP_NAME_2,

--- a/tests/integration/test_nginx_route.py
+++ b/tests/integration/test_nginx_route.py
@@ -124,7 +124,7 @@ async def test_ingress_connectivity_different_backend(model: Model):
     assert response.text == "ok"
     assert response.status_code == 200
     # Then change the config and check if there is an error
-    await model.applications["ingress"].set_config({"backend-protocol": "AJP"})
+    await model.applications["ingress"].set_config({"backend-protocol": "FCGI"})
     await model.wait_for_idle(status="active")
     response = requests_get("http://127.0.0.1/ok", host_header="any")
     assert response.status_code == 500

--- a/tests/integration/test_nginx_route.py
+++ b/tests/integration/test_nginx_route.py
@@ -116,15 +116,15 @@ async def test_ingress_connectivity_different_backend(model: Model):
     """
     arrange: given charm has been built and deployed.
     act: change the backend protocol.
-    assert: HTTP request should be forwarded to the application via AJP
-        resulting in HTTP status code 500 Internal Server Error.
+    assert: HTTP request should be forwarded to the application via GRPC
+        resulting in HTTP status code 502 Bad Gateway.
     """
     # First check if is OK
     response = requests_get("http://127.0.0.1/ok", host_header="any")
     assert response.text == "ok"
     assert response.status_code == 200
     # Then change the config and check if there is an error
-    await model.applications["ingress"].set_config({"backend-protocol": "FCGI"})
+    await model.applications["ingress"].set_config({"backend-protocol": "GRPC"})
     await model.wait_for_idle(status="active")
     response = requests_get("http://127.0.0.1/ok", host_header="any")
     assert response.status_code == 502

--- a/tests/integration/test_nginx_route.py
+++ b/tests/integration/test_nginx_route.py
@@ -127,7 +127,7 @@ async def test_ingress_connectivity_different_backend(model: Model):
     await model.applications["ingress"].set_config({"backend-protocol": "FCGI"})
     await model.wait_for_idle(status="active")
     response = requests_get("http://127.0.0.1/ok", host_header="any")
-    assert response.status_code == 500
+    assert response.status_code == 502
     # Undo the change and check again
     await model.applications["ingress"].set_config({"backend-protocol": "HTTP"})
     await model.wait_for_idle(status="active")


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Use the full certificate chain from the `tls-certificates` relation instead of only the leaf certificate.

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->