### PR TITLE
Add security explanation docs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+### 2025-06-20
+
+- Add security overview documentation under docs/explanation.
+
 ### 2025-06-10
 
 - Add changelog for tracking user-relevant changes.

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -11,11 +11,14 @@ Outdated dependencies can contain known vulnerabilities for attackers to exploit
 ### Good practices
 
 The dependencies used by the charm is tied to the charm revision.
-Updating the charm will ensure the latest security patch are used.
+Updating the charm will ensure the latest version of the dependencies are used.
+
+Using the latest version of Juju will ensure the latest security fix for Juju is applied as well.
 
 ### Summary
 
 - Regularly update the charm revision.
+- Regularly update the Juju version.
 
 ## Machine-in-the-middle attack
 

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -1,0 +1,36 @@
+# Security in NGINX Ingress Integrator charm
+
+This document describes the security design of the NGINX Ingress Integrator charm.
+The charm manages an [NGINX web server](https://nginx.org/) as an ingress proxy.
+This document will detail the risks and good practices of operating the charm.
+
+## Machine-in-the-middle attack
+
+This type of attack refers to an attacker intercepting messages and pretending to be the intended recipient of the message.
+For example, if an user tries to access `ubuntu.com`, an attacker might intercept the packets and pretend to be `ubuntu.com`, and trick the user into reveal their password.
+The way to prevent this would be using TLS certificates to validate the identity of the recipient.
+
+As an ingress proxy, clients would be sending requests to the charm.
+Encrypting these requests would help to prevent any machine-in-the-middle attack.
+This can be achieved by giving a TLS certificate to the charm, configuring it to accept HTTPS request over the unencrypted HTTP request.
+See [how to secure an Ingress with TLS](https://charmhub.io/nginx-ingress-integrator/docs/secure-an-ingress-with-tls) for how to achieve this.
+
+### Good practices
+
+- Use TLS certificates to encrypt traffic.
+
+## Denial-of-service(DoS) attack
+
+This type of attack refers to attackers overloading a service by issuing many requests in a short period of time.
+Hoping to exhaust its resources, e.g., memory, CPU cycles.
+
+The common way to deal with this type of attack is by limiting the number of requests per IP address.
+While it does not prevent all forms of DoS attacks, it is generally an effective mitigation strategy.
+
+The charm offers configuration to set rate-limit by IP address, and an allowlist to exempt IP addresses from rate-limit.
+The allowlist is meant for trusted IP addresses, and might issue lots of requests.
+
+### Good practices
+
+- Set a reasonable rate limit via the [limit-rps charm configuration](https://charmhub.io/nginx-ingress-integrator/configurations#limit-rps).
+- Use the allowlist if needed via the [limit-whitelist charm configuration](https://charmhub.io/nginx-ingress-integrator/configurations#limit-whitelist)

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -4,6 +4,19 @@ This document describes the security design of the NGINX Ingress Integrator char
 The charm manages an [NGINX web server](https://nginx.org/) as an ingress proxy.
 This document will detail the risks and good practices of operating the charm.
 
+## Outdated dependencies
+
+Outdated dependencies can contain known vulnerabilities for attackers to exploit.
+
+### Good practices
+
+The dependencies used by the charm is tied to the charm revision.
+Updating the charm will ensure the latest security patch are used.
+
+### Summary
+
+- Regularly update the charm revision.
+
 ## Machine-in-the-middle attack
 
 This type of attack refers to an attacker intercepting messages and pretending to be the intended recipient of the message.
@@ -12,10 +25,13 @@ The way to prevent this would be using TLS certificates to validate the identity
 
 As an ingress proxy, clients would be sending requests to the charm.
 Encrypting these requests would help to prevent any machine-in-the-middle attack.
+
+### Good practices
+
 This can be achieved by giving a TLS certificate to the charm, configuring it to accept HTTPS request over the unencrypted HTTP request.
 See [how to secure an Ingress with TLS](https://charmhub.io/nginx-ingress-integrator/docs/secure-an-ingress-with-tls) for how to achieve this.
 
-### Good practices
+### Summary
 
 - Use TLS certificates to encrypt traffic.
 
@@ -25,12 +41,14 @@ This type of attack refers to attackers overloading a service by issuing many re
 Attackers hope to exhaust the service's resources, e.g., memory and CPU cycles.
 
 The common way to deal with this type of attack is by limiting the number of requests per IP address.
-While it does not prevent all forms of DoS attacks, it is generally an effective mitigation strategy.
+While it does not prevent all DoS attacks depending on the scale of the attack, it is generally an effective mitigation strategy.
+
+### Good practices
 
 The charm offers configuration to set a rate-limit by IP address, and an allow list to exempt IP addresses from the rate-limit.
 The allow list is meant for trusted IP addresses, and might issue lots of requests.
 
-### Good practices
+### Summary
 
 - Set a reasonable rate limit via the [`limit-rps` charm configuration](https://charmhub.io/nginx-ingress-integrator/configurations#limit-rps).
 - Use the allow list if needed via the [`limit-whitelist` charm configuration](https://charmhub.io/nginx-ingress-integrator/configurations#limit-whitelist)

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -19,18 +19,18 @@ See [how to secure an Ingress with TLS](https://charmhub.io/nginx-ingress-integr
 
 - Use TLS certificates to encrypt traffic.
 
-## Denial-of-service(DoS) attack
+## Denial-of-service (DoS) attack
 
 This type of attack refers to attackers overloading a service by issuing many requests in a short period of time.
-Hoping to exhaust its resources, e.g., memory, CPU cycles.
+Attackers hope to exhaust the service's resources, e.g., memory and CPU cycles.
 
 The common way to deal with this type of attack is by limiting the number of requests per IP address.
 While it does not prevent all forms of DoS attacks, it is generally an effective mitigation strategy.
 
-The charm offers configuration to set rate-limit by IP address, and an allowlist to exempt IP addresses from rate-limit.
-The allowlist is meant for trusted IP addresses, and might issue lots of requests.
+The charm offers configuration to set a rate-limit by IP address, and an allow list to exempt IP addresses from the rate-limit.
+The allow list is meant for trusted IP addresses, and might issue lots of requests.
 
 ### Good practices
 
-- Set a reasonable rate limit via the [limit-rps charm configuration](https://charmhub.io/nginx-ingress-integrator/configurations#limit-rps).
-- Use the allowlist if needed via the [limit-whitelist charm configuration](https://charmhub.io/nginx-ingress-integrator/configurations#limit-whitelist)
+- Set a reasonable rate limit via the [`limit-rps` charm configuration](https://charmhub.io/nginx-ingress-integrator/configurations#limit-rps).
+- Use the allow list if needed via the [`limit-whitelist` charm configuration](https://charmhub.io/nginx-ingress-integrator/configurations#limit-whitelist)

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -10,7 +10,7 @@ Outdated dependencies can contain known vulnerabilities for attackers to exploit
 
 ### Good practices
 
-The dependencies used by the charm is tied to the charm revision.
+The dependencies used by the charm are tied to the charm revision.
 Updating the charm will ensure the latest version of the dependencies are used.
 
 Using the latest version of Juju will ensure the latest security fix for Juju is applied as well.
@@ -31,7 +31,7 @@ Encrypting these requests would help to prevent any machine-in-the-middle attack
 
 ### Good practices
 
-This can be achieved by giving a TLS certificate to the charm, configuring it to accept HTTPS request over the unencrypted HTTP request.
+Encryption can be achieved by giving a TLS certificate to the charm, configuring it to accept HTTPS request over the unencrypted HTTP request.
 See [how to secure an Ingress with TLS](https://charmhub.io/nginx-ingress-integrator/docs/secure-an-ingress-with-tls) for how to achieve this.
 
 ### Summary


### PR DESCRIPTION
### Overview

<!-- A high level overview of the change -->
Docs only change.

Add security explanation docs.

The [OWASP ModSecurity Core Rule Set](https://coreruleset.org/) will be covered in a separate docs task, a story for this in added in backlog.

### Rationale

<!-- The reason the change is needed -->


### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->