### PR TITLE
Use new team name in CODEOWNERS

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -8,14 +8,14 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      channel: 1.32-strict/stable
+      channel: 1.34-strict/stable
       modules: '["test_cert_relation", "test_ingress_relation", "test_nginx_route"]'
       juju-channel: 3.6/stable
   integration-tests-juju2:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      channel: 1.28/stable
+      channel: 1.24/stable
       modules: '["test_ingress_relation", "test_nginx_route"]'
       juju-channel: 2.9/stable
       test-tox-env: integration-juju2

--- a/.github/workflows/integration_test_arm64.yaml
+++ b/.github/workflows/integration_test_arm64.yaml
@@ -8,7 +8,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      channel: 1.28-strict/stable
+      channel: 1.34-strict/stable
       modules: '["test_cert_relation", "test_ingress_relation", "test_nginx_route"]'
       juju-channel: 3.6/stable
       self-hosted-runner: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @canonical/is-charms
+*       @canonical/platform-engineering


### PR DESCRIPTION
Replace references to is-charms to platform-engineering in CODEOWNERS