### PR TITLE
Isd 4178 nginx ingress integrator operator update index.md and remove roadmap.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Refer to the [tutorial](https://charmhub.io/nginx-ingress-integrator/docs/gettin
 Refer to [How to secure an Ingress with TLS](https://charmhub.io/nginx-ingress-integrator/docs/secure-an-ingress-with-tls) for step-by-step instructions.
 
 #### Add the ingress relation
-Refer to [How to add the Ingress relation](https://charmhub.io/nginx-ingress-integrator/docs/add-the-ingress-relation) for step-by-step instructions.
+Refer to [How to add the Ingress relation](https://charmhub.io/nginx-ingress-integrator/docs/add-the-nginx-route-relation) for step-by-step instructions.
 
 
 ## Integrations

--- a/docs/explanation/roadmap.md
+++ b/docs/explanation/roadmap.md
@@ -1,5 +1,0 @@
-Below is the roadmap for the Nginx Ingress Integrator Operator.
-
-## October 2022 to April 2023
-* Documentation improvements - updating the home page, integrating the [Diátaxis documentation framework](https://diataxis.fr/) and including project governance information.
-* Upgrade [Python Kubernetes library](https://github.com/canonical/nginx-ingress-integrator-operator/blob/main/requirements.txt). Currently the charm is using an older version of the python Kubernetes library, and we will update it to use a more recent version, taking into account supported versions of Kubernetes.

--- a/docs/how-to/add-the-nginx-route-relation.md
+++ b/docs/how-to/add-the-nginx-route-relation.md
@@ -1,7 +1,7 @@
 # How to add the Nginx-route relation
 
 The `nginx-route` relation is preferred over the `ingress` relation if you want to use nginx-specific features, such as owasp-modsecurity-crs. If you need
-something more generic then please follow the [ingress relation](https://charmhub.io/nginx-ingress-integrator/docs/add-the-ingress-relation) tutorial instead.
+something more generic then please follow the [ingress relation](https://charmhub.io/nginx-ingress-integrator/docs/add-the-nginx-route-relation) tutorial instead.
 
 ## Add the `nginx-route` relation to your charm code
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,4 +36,3 @@ If there's a particular area of documentation that you'd like to see that's miss
 1. [Explanation](explanation)
   1. [Architecture](explanation/architecture.md)
   1. [What is Ingress?](explanation/what-is-ingress.md)
-  1. [Roadmap](explanation/roadmap.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,4 +35,5 @@ If there's a particular area of documentation that you'd like to see that's miss
   1. [Libraries](https://charmhub.io/nginx-ingress-integrator/libraries/ingress)
 1. [Explanation](explanation)
   1. [Architecture](explanation/architecture.md)
+  1. [Security](explanation/security.md)
   1. [What is Ingress?](explanation/what-is-ingress.md)

--- a/docs/reference/external-access.md
+++ b/docs/reference/external-access.md
@@ -1,3 +1,0 @@
-# External access
-
-This charm does not require any external access to be deployed.


### PR DESCRIPTION
Update the documentation by removing deprecated pages, and link Security in the table of content.