### PR TITLE
Update the tutorial to use concierge

### DIFF
--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -30,8 +30,12 @@ ingress for the WordPress web application, which is provided by the
 
 ````{tip}
 You can use Multipass to create an isolated environment by running:
-```
+```bash
 multipass launch 24.04 --name charm-tutorial-vm --cpus 4 --memory 8G --disk 50G
+```
+To work inside the Multipass VM run the following command:
+```bash
+multipass shell charm-tutorial-vm
 ```
 ````
 
@@ -61,22 +65,9 @@ If Concierge did not perform the bootstrap, run:
 juju bootstrap microk8s tutorial-controller
 ```
 
-
 <!-- SPREAD SKIP END -->
 
-
-
 ## Set up the environment
-
-To be able to work inside the Multipass VM, log in with the following command:
-
-```bash
-multipass shell charm-tutorial-vm 
-```
-
-```{note}
-If you're working locally, you don't need to do this step.
-```
 
 To manage resources effectively and to separate this tutorial's workload from
 your usual work, create a new model in the MicroK8s controller using the following command:
@@ -111,13 +102,13 @@ charm and hence, [`mysql-k8s`](https://charmhub.io/mysql-k8s) charm will be used
 Start off by deploying the WordPress charm. By default it will deploy the latest stable release of
 the `wordpress-k8s` charm.
 
-```
+```bash
 juju deploy wordpress-k8s
 ```
 
 Now deploy the `mysql-k8s` charm and integrate it with the `wordpress-k8s` charm.
 
-```
+```bash
 juju deploy mysql-k8s --trust
 juju integrate wordpress-k8s mysql-k8s:database
 ```
@@ -154,7 +145,7 @@ integrate it with the `wordpress-k8s` charm. `--trust` is needed because
 the `nginx-ingress-integrator` charm requires elevated permission to 
 create ingress-related resources in Kubernetes clusters.
 
-```
+```bash
 juju deploy nginx-ingress-integrator --trust
 juju integrate wordpress-k8s nginx-ingress-integrator
 ```
@@ -192,7 +183,7 @@ address is `127.0.0.1`, but it may vary based on your Kubernetes cluster
 setup. If unknown, you can find the ingress address in the 
 `nginx-ingress-integrator` charm status message.
 
-```
+```bash
 curl -H "Host: wordpress-k8s" http://127.0.0.1
 ```
 
@@ -208,7 +199,7 @@ Now let's use the `service-hostname` configuration of the
 
 Now update the `service-hostname` configuration to a new value:
 
-```
+```bash
 juju config nginx-ingress-integrator service-hostname=wordpress.test
 ```
 
@@ -231,7 +222,7 @@ curl -H "Host: wordpress-k8s" http://127.0.0.1
 But if you use the new hostname (`wordpress.test`) we just set, you can
 access WordPress without any problem:
 
-```
+```bash
 curl -H "Host: wordpress.test" http://127.0.0.1
 ```
 

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -12,17 +12,6 @@ step of deploying the `nginx-ingress-integrator` charm to provide
 ingress for the WordPress web application, which is provided by the
 `wordpress-k8s` charm.
 
-## What you'll need
-
-- A working station, e.g., a laptop, with AMD64 architecture.
-- Juju 3 installed. For more information about how to install Juju, see {ref}`Get started with Juju <juju:tutorial>`.
-- Juju bootstrapped to a MicroK8s controller: `juju bootstrap microk8s tutorial-controller`
-
-```{note}
-You can get a working setup by using a Multipass VM as outlined in the 
-{ref}`Set up your test environment <juju:set-things-up>` guide.
-```
-
 ## What you'll do
 
 - Deploy the `wordpress-k8s` charm
@@ -31,12 +20,58 @@ You can get a working setup by using a Multipass VM as outlined in the
 - Test the ingress it creates.
 - Configure the hostname for host-based routing
 
+<!-- SPREAD SKIP -->
+
+## What you'll need
+
+- A working station, e.g., a laptop, with AMD64 architecture.
+- Juju 3 installed. For more information about how to install Juju, see {ref}`Get started with Juju <juju:tutorial>`.
+- Juju bootstrapped to a MicroK8s controller: `juju bootstrap microk8s tutorial-controller`
+
+````{tip}
+You can use Multipass to create an isolated environment by running:
+```
+multipass launch 24.04 --name charm-tutorial-vm --cpus 4 --memory 8G --disk 50G
+```
+````
+
+This tutorial requires the following software to be installed on your working station
+(either locally or in the Multipass VM):
+
+- Juju 3
+- MicroK8s 1.33
+
+Use [Concierge](https://github.com/canonical/concierge) to set up Juju and MicroK8s:
+
+```
+sudo snap install --classic concierge
+sudo concierge prepare -p microk8s
+```
+
+This first command installs Concierge, and the second command uses Concierge to install
+and configure Juju and MicroK8s.
+
+For this tutorial, Juju must be bootstrapped to a MicroK8s controller. Concierge should
+complete this step for you, and you can verify by checking for `msg="Bootstrapped Juju" provider=microk8s`
+in the terminal output and by running `juju controllers`.
+
+If Concierge did not perform the bootstrap, run:
+
+```
+juju bootstrap microk8s tutorial-controller
+```
+
+
+<!-- SPREAD SKIP END -->
+
+
+
 ## Set up the environment
 
-To be able to work inside the Multipass VM first you need to log in with the following command:
+To be able to work inside the Multipass VM, log in with the following command:
 
 ```bash
-multipass shell my-juju-vm
+multipass shell charm-tutorial-vm 
 ```
 
 ```{note}
@@ -46,8 +81,7 @@ If you're working locally, you don't need to do this step.
 To manage resources effectively and to separate this tutorial's workload from
 your usual work, create a new model in the MicroK8s controller using the following command:
 
-
-```
+```bash
 juju add-model nginx-ingress-tutorial
 ```
 
@@ -55,7 +89,7 @@ You will also need to install Nginx ingress in the Kubernetes cluster.
 This can be achieved by enable the ingress plugin in MicroK8s using the
 following command.
 
-```
+```bash
 sudo microk8s enable ingress
 ```
 

--- a/docs/tutorial/tutorial.md
+++ b/docs/tutorial/tutorial.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    "description lang=en": "Learn the process to deploy the NGINX ingress integrator charm."
+---
+
 (tutorial_tutorial)=
 
 <!-- vale Canonical.007-Headings-sentence-case = NO -->


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Update the tutorial to use concierge

### Rationale

<!-- The reason the change is needed -->
Newer tutorials should be using concierge to install juju.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated (RTD)
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [ ] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->