### PR TITLE
fix: revert myst-parser version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,9 @@ jobs:
   unit-tests:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
     with:
       self-hosted-runner: false
       vale-style-check: false

--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ make lint-md
 
 ## Get started
 
-Refer to the [tutorial](https://charmhub.io/nginx-ingress-integrator/docs/getting-started) <!-- TODO: update to RTD URL once known --> for more details on getting started.
+Refer to the [tutorial](https://documentation.ubuntu.com/nginx-ingress-integrator-charm/latest/tutorial/tutorial/) for more details on getting started.
 
 ### Basic operations
 
 #### Secure an ingress with TLS
-Refer to [How to secure an Ingress with TLS](https://charmhub.io/nginx-ingress-integrator/docs/secure-an-ingress-with-tls) <!-- TODO: update to RTD URL once known --> for step-by-step instructions.
+Refer to [How to secure an Ingress with TLS](https://documentation.ubuntu.com/nginx-ingress-integrator-charm/latest/how-to/secure-an-ingress-with-tls/) for step-by-step instructions.
 
 #### Add the ingress relation
-Refer to [How to add the Ingress relation](https://charmhub.io/nginx-ingress-integrator/docs/add-the-nginx-route-relation) <!-- TODO: update to RTD URL once known --> for step-by-step instructions.
+Refer to [How to add the Ingress relation](https://documentation.ubuntu.com/nginx-ingress-integrator-charm/latest/how-to/add-the-nginx-route-relation/) for step-by-step instructions.
 
 
 ## Integrations
@@ -84,5 +84,5 @@ about integrations.
 
 ## Project and community
 * [Issues](https://github.com/canonical/nginx-ingress-integrator-operator/issues)
-* [Contributing](https://charmhub.io/nginx-ingress-integrator/docs/contribute)
+* [Contributing](https://documentation.ubuntu.com/nginx-ingress-integrator-charm/latest/how-to/contribute/)
 * [Matrix](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -379,4 +379,5 @@ if os.path.exists('./reuse/substitutions.yaml'):
 intersphinx_mapping = {
     'starter-pack': ("https://canonical-starter-pack.readthedocs-hosted.com/stable/", None),
     "juju": ("https://documentation.ubuntu.com/juju/3.6/", None),
+    "ops": ("https://documentation.ubuntu.com/ops/latest/", None),
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ If there's a particular area of documentation that you'd like to see that's miss
 
 The NGINX ingress integrator charm is a member of the Ubuntu family. It's an open-source project that warmly welcomes community projects, contributions, suggestions, fixes, and constructive feedback.
 
-- [Code of conduct](https://ubuntu.com/community/code-of-conduct)
+- [Code of conduct](https://ubuntu.com/community/docs/ethos/code-of-conduct)
 - [Get support](https://discourse.charmhub.io/)
 - [Join our online chat](https://matrix.to/#/#charmhub-charmdev:ubuntu.com)
 - [Contribute](how_to_contribute)

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -82,7 +82,7 @@ details, see the documentation for the charm libraries.
 
 The `src/charm.py` is the default entry point for a charm and has the 
 `NginxIngressCharm` Python class which inherits from `CharmBase`. `CharmBase` is 
-the base class from which all Charms are formed, defined by [Ops](https://juju.is/docs/sdk/ops)
+the base class from which all Charms are formed, defined by {doc}`Ops <ops:index>`
 (Python framework for developing charms).
 
 ```{note}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 canonical-sphinx==0.6.0
 
 # Extensions previously auto-loaded by canonical-sphinx
-myst-parser==5.1.0
+myst-parser==4.0.1
 sphinx-autobuild==2025.8.25
 sphinx-design==0.7.0
 sphinx-notfound-page==1.1.0
@@ -27,8 +27,10 @@ packaging==26.2
 sphinxcontrib-svg2pdfconverter[CairoSVG]==2.1.0
 sphinx-last-updated-by-git==0.3.8
 sphinx-sitemap==2.9.0
-sphinxcontrib-mermaid==2.0.2
 
 # Vale dependencies
 rst2html==2020.7.4
 vale==3.13.0.0
+
+# Additional extensions
+sphinxcontrib-mermaid==2.0.2


### PR DESCRIPTION
### Overview

Revert https://github.com/canonical/nginx-ingress-integrator-operator/pull/407

### Rationale

All the documentation checks are broken
I also opened https://github.com/canonical/canonical-repo-automation/pull/842 so that the documentation checks are required for renovate PRs, so this doesn't happen again

Note that the "check URLs" workflow is expected to fail because the base branch contains the problematic myst-parse version.

### Juju events changes

None

### Module changes

None

### Library changes

None

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is updated (RTD)
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [ ] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->