### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/publish_charm.yaml
+++ b/.github/workflows/publish_charm.yaml
@@ -3,10 +3,13 @@ name: Publish to edge
 on:
   push:
     branches:
-      - main
-      - track/*
+    - main
+    - track/*
 
 jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    permissions:
+      actions: read
+      contents: write
     secrets: inherit

--- a/.github/workflows/publish_charm_arm64.yaml
+++ b/.github/workflows/publish_charm_arm64.yaml
@@ -3,12 +3,15 @@ name: Publish to edge arm64
 on:
   push:
     branches:
-      - main
-      - track/*
+    - main
+    - track/*
 
 jobs:
   publish-to-edge-arm64:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    permissions:
+      actions: read
+      contents: write
     secrets: inherit
     with:
       integration-test-workflow-file: "integration_test_arm64.yaml"


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.