### PR TITLE
Add documentation for OWASP ModSecurity

### DIFF
--- a/docs/how-to/enable-owasp-modsecurity.md
+++ b/docs/how-to/enable-owasp-modsecurity.md
@@ -16,7 +16,7 @@ detection rules for use with ModSecurity or compatible web application
 firewalls. Enable OWASP ModSecurity and the core rule set by
 setting the `owasp-modsecurity-crs` charm configuration to `true`:
 
-```bash
+```{bash}
 juju config nginx-ingress-integrator owasp-modsecurity-crs=true
 ```
 
@@ -31,6 +31,14 @@ Separate each rule using a new line (`\n`).
 
 See the [ModSecurity reference](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v3.x%29)
 manual for the full rule configuration directives.
+
+See the [`owasp-modsecurity-custom-rules` configuration description](https://charmhub.io/nginx-ingress-integrator/configurations#owasp-modsecurity-custom-rules)
+for the full configuration format, and here's an example of setting
+custom rules using a juju command:
+
+```{bash}
+juju config nginx-ingress-integrator owasp-modsecurity-custom-rules="SecAction id:900130,phase:1,nolog,pass,t:none,setvar:tx.crs_exclusions_wordpress=1\n"
+```
 
 ```{warning}
 This option is only effective when `owasp-modsecurity-crs` is set to

--- a/docs/how-to/enable-owasp-modsecurity.md
+++ b/docs/how-to/enable-owasp-modsecurity.md
@@ -4,29 +4,28 @@
 
 [ModSecurity](https://www.modsecurity.org/) is an open-source,
 cross-platform web application firewall (WAF) engine for Apache, IIS,
-and Nginx that is developed by OWASP. You can enable the ModSecurity
-firewall in the Nginx ingress integrator charm using the
+and NGINX that is developed by OWASP. You can enable the ModSecurity
+firewall in the NGINX ingress integrator charm using the
 `owasp-modsecurity-crs` and `owasp-modsecurity-custom-rules` charm
 configuration options.
 
-# Enable OWASP ModSecurity with core rule set
+## Enable OWASP ModSecurity with core rule set
 
 The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack
 detection rules for use with ModSecurity or compatible web application
-firewalls. You can enable OWASP ModSecurity and the core rule set by
-setting the `owasp-modsecurity-crs` charm configuration to `true`. For
-example:
+firewalls. Enable OWASP ModSecurity and the core rule set by
+setting the `owasp-modsecurity-crs` charm configuration to `true`:
 
 ```bash
 juju config nginx-ingress-integrator owasp-modsecurity-crs=true
 ```
 
-# Customize ModSecurity rules
+## Customize ModSecurity rules
 
-You can also enable additional rules outside the core rule set by
+Enable additional rules outside the core rule set by
 setting the `owasp-modsecurity-custom-rules` charm configuration option.
-The `owasp-modsecurity-custom-rules` configuration option will be put in
-the `nginx.ingress.kubernetes.io/modsecurity-snippet` Nginx ingress
+This configuration option will be put in
+the `nginx.ingress.kubernetes.io/modsecurity-snippet` NGINX ingress
 annotation with other charm-generated configuration snippets.
 
 See the [ModSecurity reference](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v3.x%29)

--- a/docs/how-to/enable-owasp-modsecurity.md
+++ b/docs/how-to/enable-owasp-modsecurity.md
@@ -16,7 +16,7 @@ detection rules for use with ModSecurity or compatible web application
 firewalls. Enable OWASP ModSecurity and the core rule set by
 setting the `owasp-modsecurity-crs` charm configuration to `true`:
 
-```{bash}
+```bash
 juju config nginx-ingress-integrator owasp-modsecurity-crs=true
 ```
 
@@ -36,7 +36,7 @@ See the [`owasp-modsecurity-custom-rules` configuration description](https://cha
 for the full configuration format, and here's an example of setting
 custom rules using a juju command:
 
-```{bash}
+```bash
 juju config nginx-ingress-integrator owasp-modsecurity-custom-rules="SecAction id:900130,phase:1,nolog,pass,t:none,setvar:tx.crs_exclusions_wordpress=1\n"
 ```
 

--- a/docs/how-to/enable-owasp-modsecurity.md
+++ b/docs/how-to/enable-owasp-modsecurity.md
@@ -31,5 +31,7 @@ annotation with other charm-generated configuration snippets.
 See the [ModSecurity reference](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v3.x%29)
 manual for the full rule configuration directives.
 
+```{warning}
 This option is only effective when `owasp-modsecurity-crs` is set to
 `true`.
+```

--- a/docs/how-to/enable-owasp-modsecurity.md
+++ b/docs/how-to/enable-owasp-modsecurity.md
@@ -27,6 +27,7 @@ setting the `owasp-modsecurity-custom-rules` charm configuration option.
 This configuration option will be put in
 the `nginx.ingress.kubernetes.io/modsecurity-snippet` NGINX ingress
 annotation with other charm-generated configuration snippets.
+Separate each rule using a new line (`\n`).
 
 See the [ModSecurity reference](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v3.x%29)
 manual for the full rule configuration directives.

--- a/docs/how-to/enable-owasp-modsecurity.md
+++ b/docs/how-to/enable-owasp-modsecurity.md
@@ -1,0 +1,36 @@
+(how_to_enable_owasp_modsecurity_firewall)=
+
+# How to enable the OWASP ModSecurity web application firewall
+
+[ModSecurity](https://www.modsecurity.org/) is an open-source,
+cross-platform web application firewall (WAF) engine for Apache, IIS,
+and Nginx that is developed by OWASP. You can enable the ModSecurity
+firewall in the Nginx ingress integrator charm using the
+`owasp-modsecurity-crs` and `owasp-modsecurity-custom-rules` charm
+configuration options.
+
+# Enable OWASP ModSecurity with core rule set
+
+The OWASP ModSecurity Core Rule Set (CRS) is a set of generic attack
+detection rules for use with ModSecurity or compatible web application
+firewalls. You can enable OWASP ModSecurity and the core rule set by
+setting the `owasp-modsecurity-crs` charm configuration to `true`. For
+example:
+
+```bash
+juju config nginx-ingress-integrator owasp-modsecurity-crs=true
+```
+
+# Customize ModSecurity rules
+
+You can also enable additional rules outside the core rule set by
+setting the `owasp-modsecurity-custom-rules` charm configuration option.
+The `owasp-modsecurity-custom-rules` configuration option will be put in
+the `nginx.ingress.kubernetes.io/modsecurity-snippet` Nginx ingress
+annotation with other charm-generated configuration snippets.
+
+See the [ModSecurity reference](https://github.com/owasp-modsecurity/ModSecurity/wiki/Reference-Manual-%28v3.x%29)
+manual for the full rule configuration directives.
+
+This option is only effective when `owasp-modsecurity-crs` is set to
+`true`.

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -23,6 +23,7 @@ basic operations you can complete with the charm.
     :maxdepth: 1
 
     Add the NGINX route relation <add-the-nginx-route-relation>
+    Enable OWASP ModSecurity <enable-owasp-modsecurity>
     Secure an ingress with TLS <secure-an-ingress-with-tls>
     Support multiple relations <support-multiple-relations>
 


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add documentation for OWASP ModSecurity related charm configurations.

### Rationale

<!-- The reason the change is needed -->

### Juju events changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated (RTD)
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`)
- [x] The changelog is updated with changes that affect the users of the charm.

<!-- Explanation for any unchecked items above -->