### PR TITLE
ci: add pull-requests: write permission to comment workflow

### DIFF
--- a/.github/workflows/comment.yaml
+++ b/.github/workflows/comment.yaml
@@ -6,7 +6,12 @@ on:
     types:
       - completed
 
+permissions:
+  pull-requests: write
+
 jobs:
   comment-on-pr:
     uses: canonical/operator-workflows/.github/workflows/comment.yaml@main
+    permissions:
+      pull-requests: write
     secrets: inherit


### PR DESCRIPTION
The `comment.yaml` workflow was failing with `startup_failure` because the `operator-workflows/comment.yaml` reusable workflow needs `pull-requests: write` to post Allure report comments on PRs. Without explicit permission grants, GitHub blocks the nested job.

Fixes: https://github.com/canonical/nginx-ingress-integrator-operator/actions/runs/26806105516